### PR TITLE
perf: call `module.enableCompileCache()`

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+import module from 'node:module'
 import { runCLI } from './cli'
 
+try {
+  module.enableCompileCache?.()
+} catch {}
 runCLI()


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Calls the new module.enableCompileCache() API (https://github.com/nodejs/node/pull/54501) which is available since Node.js 22.8.0.
```
hyperfine --warmup 3 'node ./node_modules/tsdown/dist/run.js'  # without this PR
Benchmark 1: node ./node_modules/tsdown/dist/run.js
  Time (mean ± σ):     193.6 ms ±   1.4 ms    [User: 199.1 ms, System: 19.0 ms]
  Range (min … max):   192.3 ms … 196.9 ms    15 runs

hyperfine --warmup 3 'node ./node_modules/tsdown/dist/run.js' # with this PR
Benchmark 1: node ./node_modules/tsdown/dist/run.js
  Time (mean ± σ):     177.7 ms ±   1.8 ms    [User: 181.8 ms, System: 19.5 ms]
  Range (min … max):   175.5 ms … 182.0 ms    16 runs
```
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
