### PR TITLE
refactor: replace `isBuiltin` with `builtinModules`

### DIFF
--- a/src/features/external.ts
+++ b/src/features/external.ts
@@ -47,7 +47,9 @@ export function ExternalPlugin(options: ResolvedOptions): Plugin {
           id,
           external: shouldExternal,
           moduleSideEffects:
-            id.startsWith('node:') || builtinModules.includes(id) ? false : undefined,
+            id.startsWith('node:') || builtinModules.includes(id)
+              ? false
+              : undefined,
         }
       }
     },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
After https://github.com/rolldown/tsdown/commit/25ec6b159cc388aad81734134011187048a842c4  tsdown currently shows that the supported node version is 18, but the `isBuiltin` method is only supported in 18.6.0, so use `builtinModules` instead.

https://nodejs.org/docs/latest-v20.x/api/module.html#moduleisbuiltinmodulename
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
