### PR TITLE
fix: normalize windows paths for workspace filter

### DIFF
--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -9,6 +9,7 @@ import { resolveTarget } from '../features/target'
 import { resolveTsconfig } from '../features/tsconfig'
 import { resolveRegex, slash } from '../utils/general'
 import { logger } from '../utils/logger'
+import { normalizePathFor } from '../utils/normalize-path'
 import { normalizeFormat, readPackageJson } from '../utils/package'
 import type { Awaitable } from '../utils/types'
 import { loadConfigFile, loadViteConfig } from './config'
@@ -115,6 +116,10 @@ async function resolveWorkspace(
   if (packages.length === 0) {
     throw new Error('No workspace packages found, please check your config')
   }
+
+  // Normalize for windows paths
+  packages = normalizePathFor(packages)
+  options.filter = normalizePathFor(options.filter)
 
   if (options.filter) {
     options.filter = resolveRegex(options.filter)

--- a/src/utils/normalize-path.ts
+++ b/src/utils/normalize-path.ts
@@ -1,0 +1,11 @@
+export function normalizePathFor<
+  T extends string | RegExp | string[] | undefined = string,
+>(arg: T): T {
+  if (arg === undefined) {
+    return arg
+  }
+
+  return Array.isArray(arg)
+    ? (arg.map(normalizePathFor) as T)
+    : (arg.toString().replaceAll('\\', '/') as T)
+}

--- a/tests/utilities.test.ts
+++ b/tests/utilities.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { normalizePathFor } from '../src/utils/normalize-path'
+
+describe('utilities', () => {
+  test('normalizePathFor', () => {
+    expect(normalizePathFor('')).toMatchInlineSnapshot(`""`)
+    expect(normalizePathFor('a/b/c')).toMatchInlineSnapshot(`"a/b/c"`)
+    expect(normalizePathFor(String.raw`a\b\c`)).toMatchInlineSnapshot(`"a/b/c"`)
+    expect(
+      normalizePathFor(String.raw`C:\Program Files\my-dir\test.js`),
+    ).toMatchInlineSnapshot(`"C:/Program Files/my-dir/test.js"`)
+    expect(normalizePathFor(['a/b/c', 'd/e/f'])).toMatchInlineSnapshot(`
+      [
+        "a/b/c",
+        "d/e/f",
+      ]
+    `)
+    expect(
+      normalizePathFor([String.raw`packages\foo`, String.raw`packages\bar`]),
+    ).toMatchInlineSnapshot(`
+      [
+        "packages/foo",
+        "packages/bar",
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

- [x] Simplify path normalizing for workspace filter and packages path result searched by glob 
- [x] Add unit test for normalize path function

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

This PR is a supplement for #376 

<!-- e.g. is there anything you'd like reviewers to focus on? -->
