### PR TITLE
refactor: stop using deprecated `patterns` option

### DIFF
--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -91,8 +91,7 @@ async function resolveWorkspace(
   } = workspace
   if (packages === 'auto') {
     packages = (
-      await glob({
-        patterns: '**/package.json',
+      await glob('**/package.json', {
         ignore: exclude,
         cwd: rootCwd,
         expandDirectories: false,
@@ -102,8 +101,7 @@ async function resolveWorkspace(
       .map((file) => slash(path.resolve(rootCwd, file, '..')))
   } else {
     packages = (
-      await glob({
-        patterns: packages,
+      await glob(packages, {
         ignore: exclude,
         cwd: rootCwd,
         onlyDirectories: true,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

hi! i've noticed this project uses the `patterns` option from tinyglobby instead of providing the patterns as the first argument. this option is getting deprecated in the next tinyglobby version for consistency with all other glob libraries, which is why this PR changes the relevant lines to use the standard format

### Linked Issues

N/A

### Additional context

https://github.com/SuperchupuDev/tinyglobby/commit/9f1f13f
