### PR TITLE
fix: remove `expandDirectories` option

### DIFF
--- a/src/features/clean.ts
+++ b/src/features/clean.ts
@@ -19,7 +19,6 @@ export async function cleanOutDir(configs: ResolvedOptions[]): Promise<void> {
       cwd: config.cwd,
       absolute: true,
       onlyFiles: false,
-      expandDirectories: false,
     })
 
     const normalizedOutDir = config.outDir.replace(RE_LAST_SLASH, '')


### PR DESCRIPTION
### Description

When `expandDirectories` is set to `false`, the `files` array only contains the `dist` directory, However, due to this  
https://github.com/rolldown/tsdown/commit/0420f47860c37686a5c8542dd2aa70b8c9ed5e8a, the `dist` directory will no longer be deleted.

<img width="1079" height="640" alt="image" src="https://github.com/user-attachments/assets/08b1bb43-31bf-41c9-a37c-1f0076363e66" />

<img width="1123" height="775" alt="image" src="https://github.com/user-attachments/assets/65fa8623-de26-4531-a319-bb8602a6befc" />


### Linked Issues

### Additional context

https://github.com/rolldown/tsdown/commit/8171b96a61b09b47ca1805e006818dc84891038a

https://github.com/rolldown/tsdown/commit/0420f47860c37686a5c8542dd2aa70b8c9ed5e8a

