### PR TITLE
docs: fix entry point in tsdown configuration

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -132,7 +132,7 @@ Next, initialize the `tsdown` configuration file:
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src'],
+  entry: ['./src/index.ts'],
 })
 ```
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

On the [Getting Started](https://tsdown.dev/guide/getting-started#your-first-bundle) page, the entry point is wrong, causing the following error:

```
Error: Cannot find entry: ["./src"]
```

This PR fixes the entry point, with the following value: `["./src/index.ts"]`

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
