### PR TITLE
docs(windows): load `typedoc-sidebar.json` file via require

### DIFF
--- a/docs/.vitepress/config/theme.ts
+++ b/docs/.vitepress/config/theme.ts
@@ -1,9 +1,12 @@
 import { existsSync } from 'node:fs'
+import module from 'node:module'
 import path from 'node:path'
 import { createTranslate } from '../i18n/utils'
 import type { DefaultTheme, HeadConfig, LocaleConfig } from 'vitepress'
 
-async function getTypedocSidebar() {
+const require = module.createRequire(import.meta.url)
+
+function getTypedocSidebar() {
   const filepath = path.resolve(
     import.meta.dirname,
     '../../reference/api/typedoc-sidebar.json',
@@ -11,15 +14,14 @@ async function getTypedocSidebar() {
   if (!existsSync(filepath)) return []
 
   try {
-    return (await import(filepath, { with: { type: 'json' } }))
-      .default as DefaultTheme.SidebarItem[]
+    return require(filepath) as DefaultTheme.SidebarItem[]
   } catch (error) {
     console.error('Failed to load typedoc sidebar:', error)
     return []
   }
 }
 
-const typedocSidebar = await getTypedocSidebar()
+const typedocSidebar = getTypedocSidebar()
 
 export function getLocaleConfig(lang: string) {
   const t = createTranslate(lang)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
`docs` package using dynamic import to load `json` files, using Node 24.8.0 on Windows will fail, this PR just uses `createRequire` + `require`  to load the json file.

<img width="1694" height="422" alt="error importing json file via dynamic import" src="https://github.com/user-attachments/assets/7bade5d1-bdc4-4596-8d10-171bb852c854" />


### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
