### PR TITLE
fix: pin rolldown version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,7 +154,7 @@ catalogs:
       version: 7.3.3
 
 overrides:
-  rolldown: latest
+  rolldown: 1.0.0-beta.44
   vite: npm:rolldown-vite@latest
 
 importers:
@@ -183,7 +183,7 @@ importers:
         specifier: catalog:prod
         version: 5.5.3
       rolldown:
-        specifier: latest
+        specifier: 1.0.0-beta.44
         version: 1.0.0-beta.44
       rolldown-plugin-dts:
         specifier: catalog:prod
@@ -1170,7 +1170,7 @@ packages:
       '@ts-macro/language-plugin': '*'
       '@volar/typescript': '*'
       esbuild: '>=0.20.0'
-      rolldown: '*'
+      rolldown: 1.0.0-beta.44
       rollup: ^4.1.0
       typescript: ^5.8.0
       vitest: ^2.0.0 || ^3.0.0-0
@@ -3037,7 +3037,7 @@ packages:
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
       '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
-      rolldown: ^1.0.0-beta.9
+      rolldown: 1.0.0-beta.44
       typescript: ^5.0.0
       vue-tsc: ~3.1.0
     peerDependenciesMeta:
@@ -3054,7 +3054,7 @@ packages:
     resolution: {integrity: sha512-VfF4o0iDiT4v27cpRtj6cAKgF9ftIfbM9ntzb7GuuBtb/tUHp1gGeF8OchrwV4lckC6iKuLvsPP8FEk/stSNlQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      rolldown: '*'
+      rolldown: 1.0.0-beta.44
 
   rolldown-vite@7.1.19:
     resolution: {integrity: sha512-4TRFlbv0F8zE0EbaSAuzHEGlBRRTSaMd3QP8Qz0VTeSb6Z+kpCXSAw2k2QimTuDCJSxdYItcjZjWXtn0j6ksTg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,7 +55,7 @@ catalogs:
     giget: ^2.0.0
     hookable: ^5.5.3
     package-manager-detector: ^1.4.1
-    rolldown: latest
+    rolldown: 1.0.0-beta.44
     rolldown-plugin-dts: ^0.16.12
     semver: ^7.7.3
     tinyexec: ^1.0.1


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`tsdown` depends on `rolldown@latest`. One of the reasons is that we cannot set something like `rolldown@^1.0.0-beta.44`.

> [source](https://github.com/rolldown/tsdown/issues/500#issuecomment-3305920284)
> 
> `yarn add -D rolldown@^1.0.0-beta.30` installs `1.0.0-beta.9-commit.d91dfb5`


However, depending on `rolldown@latest` causes issues for projects using `pnpm`. Let's say I have a project with `tsdown@0.15.7` and `rolldown@1.0.0-beta.43` installed. Running `pnpm add is-even` will also bump `rolldown` to the latest `1.0.0-beta.44`. This is not my intention, and the unintentional update of `rolldown` may lead to unexpected issues. An example of this issue can be found at https://github.com/rolldown/tsdown/issues/551, where the new deprecated warning in the console reportedly causes "our tooling to fail."

To resolve the above two issues, we need to explicitly set the `rolldown` version (without the `^` prefix).

```json
{
  "dependencies": {
    "rolldown": "1.0.0-beta.44"
  }
}
```



Once `rolldown` release `1.0.0`, we don't need this anymore. We can just set `"rolldown": "^1.0.0"` normally.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Closes https://github.com/rolldown/tsdown/issues/500 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
