### PR TITLE
docs: Mention typescript feature support / decorators

### DIFF
--- a/docs/options/target.md
+++ b/docs/options/target.md
@@ -77,6 +77,12 @@ You can also pass an array of targets to ensure compatibility across multiple en
 tsdown --target chrome100 --target node20.18
 ```
 
+# Typescript feature compatibility
+
+`tsdown` will resolve your typescript config and respect it's settings, for example for [emitting declaration files](/options/dts). However, you have to ensure that your typescript config matches your expected feature set. For example, to support [typescript decorators](https://github.com/tc39/proposal-decorators), you need to enable [`experimentalDecorators`](https://www.typescriptlang.org/tsconfig/#experimentalDecorators) in your tsconfig.
+
+To customize if and how to load the tsconfig, see the [reference](https://tsdown.dev/reference/api/Interface.Options#tsconfig).
+
 # CSS Targeting
 
 `tsdown` can also downlevel CSS features to match your specified browser targets. For example, a CSS nesting `&` selector will be flattened if the target is `chrome108` or lower.


### PR DESCRIPTION
### Description

Update the `target` docs page to mention that it's required to change the `tsconfig` settings for certain typescript features, like TC39 decorators, as requested in https://github.com/rolldown/tsdown/issues/247

I added a new section `Typescript feature compatibility` on the `options/target` page, because it's somewhat related and I didn't want to create a new page for this. Please let me know if I should change the naming, document more features etc.

### Linked Issues

- Issue mentioning that it's needed to change tsconfig: https://github.com/rolldown/tsdown/discussions/271
- Docs TODO issue: https://github.com/rolldown/tsdown/issues/247

### Additional context

I tested that the links work, and added the link to the `tsconfig` tsdown config option as an external link
<!-- e.g. is there anything you'd like reviewers to focus on? -->
