### PR TITLE
fix: allow to configure advanced treeshake options

### DIFF
--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -35,6 +35,7 @@ import type {
   ModuleFormat,
   ModuleTypes,
   OutputOptions,
+  TreeshakingOptions,
 } from 'rolldown'
 import type { Options as DtsOptions } from 'rolldown-plugin-dts'
 import type { Options as UnusedOptions } from 'unplugin-unused'
@@ -60,6 +61,7 @@ export type {
   PublintOptions,
   ReportOptions,
   RolldownContext,
+  TreeshakingOptions,
   TsdownChunks,
   TsdownHooks,
   UnusedOptions,
@@ -177,9 +179,11 @@ export interface Options {
   shims?: boolean
 
   /**
+   * Configure tree shaking options.
+   * @see {@link https://rolldown.rs/options/treeshake} for more details.
    * @default true
    */
-  treeshake?: boolean
+  treeshake?: boolean | TreeshakingOptions
 
   /**
    * Sets how input files are processed.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

tsdown's treeshake option now takes an config object along with enable/disable boolean, just like how its configured in rolldown 
https://rolldown.rs/options/treeshake

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

I wanted to configure `treeshake.moduleSideEffects` option based on the rolldown docs, but tsdown gave me type errors, still I added the option ignoring the type error and it worked as expected, so this PR adds the relevant type to the config

<!-- e.g. is there anything you'd like reviewers to focus on? -->
