### PR TITLE
fix(exports): use correct indentation for output

### DIFF
--- a/src/features/exports.test.ts
+++ b/src/features/exports.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import process from 'node:process'
 import { describe, test } from 'vitest'
-import { detectIndentation, generateExports } from './exports.ts'
+import { detectIndent, generateExports } from './exports.ts'
 import type { OutputChunk } from 'rolldown'
 
 const cwd = process.cwd()
@@ -402,21 +402,21 @@ describe.concurrent('generateExports', () => {
   })
 })
 
-describe('detectIndentation', () => {
+describe('detectIndent', () => {
   test('two spaces', ({ expect }) => {
-    expect(detectIndentation(stringifyJson(2))).toBe(2)
+    expect(detectIndent(stringifyJson(2))).toBe(2)
   })
   test('four spaces', ({ expect }) => {
-    expect(detectIndentation(stringifyJson(4))).toBe(4)
+    expect(detectIndent(stringifyJson(4))).toBe(4)
   })
   test('tab', ({ expect }) => {
-    expect(detectIndentation(stringifyJson('\t'))).toBe('\t')
+    expect(detectIndent(stringifyJson('\t'))).toBe('\t')
   })
   test('empty', ({ expect }) => {
-    expect(detectIndentation('')).toBe(2)
+    expect(detectIndent('')).toBe(2)
   })
   test('empty line', ({ expect }) => {
-    expect(detectIndentation('{\n\n  "foo": 42 }')).toBe(2)
+    expect(detectIndent('{\n\n  "foo": 42 }')).toBe(2)
   })
 })
 

--- a/src/features/exports.ts
+++ b/src/features/exports.ts
@@ -65,14 +65,14 @@ export async function writeExports(
   }
 
   const original = await readFile(pkg.packageJsonPath, 'utf8')
-  let contents = JSON.stringify(updatedPkg, null, detectIndentation(original))
+  let contents = JSON.stringify(updatedPkg, null, detectIndent(original))
   if (original.endsWith('\n')) contents += '\n'
   if (contents !== original) {
     await writeFile(pkg.packageJsonPath, contents, 'utf8')
   }
 }
 
-export function detectIndentation(jsonText: string): string | number {
+export function detectIndent(jsonText: string): string | number {
   const lines = jsonText.split(/\r?\n/)
 
   for (const line of lines) {


### PR DESCRIPTION
### Description

Currently, when using `exports: true` with a `package.json` that's indented with four spaces, the output `package.json` will be indented with two spaces. This leads to unexpected diffs. 

This PR adds a `detectIndentation` function to `features/exports.ts` to detect the indentation that's used in the original `package.json`. The returned value is then used when overwriting the `package.json` with the new exports.

### Linked Issues
Fixes #346

### Additional context

https://github.com/rolldown/tsdown/commit/ba20fd546f8fc98db0f45900683af31bcd95b784 already improved the auto-detection the indentation of the original `package.json` but only if `\t` is used as indent. 
