### PR TITLE
docs: fix jsx transform option

### DIFF
--- a/docs/recipes/react-support.md
+++ b/docs/recipes/react-support.md
@@ -64,7 +64,9 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   inputOptions: {
-    jsx: 'react', // Use classic JSX transformation
+    transform: {
+      jsx: 'react', // Use classic JSX transformation
+    }
   },
 })
 ```

--- a/docs/zh-CN/recipes/react-support.md
+++ b/docs/zh-CN/recipes/react-support.md
@@ -64,7 +64,9 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   inputOptions: {
-    jsx: 'react', // 使用经典 JSX 转换
+    transform: {
+      jsx: 'react', // 使用经典 JSX 转换
+    }
   },
 })
 ```


### PR DESCRIPTION
### Description

`jsx` transformation option was moved under `transform` but documentation does not reflect it

### Linked Issues

\-

### Additional context

\-
