### PR TITLE
docs: improve platform docs with module resolution strategy

### DIFF
--- a/docs/options/platform.md
+++ b/docs/options/platform.md
@@ -35,7 +35,6 @@ tsdown --platform neutral
 > [!TIP]
 > Choosing the right platform ensures your code is optimized for its intended runtime. For example, use `browser` for front-end projects, `node` for server-side applications, and `neutral` for universal libraries.
 
-
 ### Module Resolution
 
 Different platforms use different resolve strategies for package entry points. The `mainFields` option determines which fields in `package.json` are checked:
@@ -64,4 +63,3 @@ export default defineConfig({
 ```
 
 See the [Rolldown resolve options documentation](https://rolldown.rs/options/resolve#mainfields) for more details.
-

--- a/docs/zh-CN/options/platform.md
+++ b/docs/zh-CN/options/platform.md
@@ -63,4 +63,3 @@ export default defineConfig({
 ```
 
 更多详情请参阅 [Rolldown 解析选项文档](https://rolldown.rs/options/resolve#mainfields)。
-


### PR DESCRIPTION
### Description

Adds documentation warning about `mainFields` configuration when using the `neutral` platform.

### Changes

- Add warning block in platform documentation (EN & ZH-CN)
- Explain that `neutral` platform defaults `mainFields` to `[]`, relying only on `exports` field
- Provide solution for resolving issues with older packages
- Link to Rolldown resolve options documentation

### Additional context

Fixes issues where users encounter `[UNRESOLVED_IMPORT]` warnings when using `neutral` platform with packages that don't have `exports` field defined.