### PR TITLE
Fix the issue where CSS entry files generate empty JS files that unexpectedly overwrite other JS outputs with the same base name

### DIFF
--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -16,7 +16,7 @@ import { mergeUserOptions } from '../config/options.ts'
 import { lowestCommonAncestor } from '../utils/fs.ts'
 import { importWithError } from '../utils/general.ts'
 import { LogLevels } from '../utils/logger.ts'
-import { CssCodeSplitPlugin } from './css.ts'
+import { CssCodeSplitPlugin, CssEntryPlugin } from './css.ts'
 import { ExternalPlugin } from './external.ts'
 import { LightningCSSPlugin } from './lightningcss.ts'
 import { NodeProtocolPlugin } from './node-protocol.ts'
@@ -160,7 +160,11 @@ async function resolveInputOptions(
     if (cssPlugin) {
       plugins.push(cssPlugin)
     }
-    plugins.push(ShebangPlugin(logger, cwd, nameLabel, isDualFormat))
+    // Remove empty JS files generated from CSS-only entries
+    plugins.push(
+      CssEntryPlugin(),
+      ShebangPlugin(logger, cwd, nameLabel, isDualFormat),
+    )
     if (globImport) {
       plugins.push(importGlobPlugin({ root: cwd }))
     }


### PR DESCRIPTION
## Summary

Fix the issue where CSS entry files generate empty JS files that unexpectedly overwrite other JS outputs with the same base name.

Closes: https://github.com/rolldown/tsdown/issues/627

## Problem

When using multiple entry files like `index.js` and `index.css`, the CSS entry generates an empty `index.js` file which overwrites the legitimate JS output:

// tsdown.config.js
export default {
  entry: ["./index.js", "./index.css"],
}**Expected output:**
- `dist/index.js` - Contains bundled JS code
- `dist/index.css` - Contains CSS code

**Actual output (before this fix):**
- `dist/index.js` - Empty (0 bytes) ❌
- `dist/index.css` - Contains CSS code

This happens because:
1. Both entries resolve to the same entry name `index` (after stripping extensions)
2. Rolldown generates a JS chunk for every entry, including CSS-only entries
3. The empty JS chunk from the CSS entry overwrites the real JS output

## Root Cause

This is fundamentally a **Rolldown behavior limitation**. Rolldown generates a JS chunk for every entry point, even when the entry is a pure CSS file. Ideally, Rolldown should natively support CSS-only entries without generating empty JS files.

> **Note:** A more elegant long-term solution would be for Rolldown to handle this natively. Consider opening an issue in [rolldown/rolldown](https://github.com/rolldown/rolldown) to request this feature.

## Solution

This PR implements a targeted fix that **only activates when there's a naming conflict**:

### 1. Detect naming conflicts in entry resolution (`entry.ts`)

When multiple entries would resolve to the same base name (e.g., `index.js` and `index.css` both → `index`), CSS entries are given a `.css` suffix to avoid collision:
- `index.js` → entry name: `index`
- `index.css` → entry name: `index.css` (only when conflict exists)

**When there's no conflict, behavior remains unchanged:**
- Single `index.css` entry → entry name: `index` (no change from before)

### 2. Add `CssEntryPlugin` to clean up conflict outputs (`css.ts`)

A new plugin that runs in `generateBundle` phase, **only for conflict cases**:
- **Removes** empty JS files from CSS entries that have `.css` in their name (conflict resolution naming)
- **Renames** CSS files with double extensions (e.g., `index.css.css` → `index.css`)

## Key Design Decisions

- **Minimal impact**: Only affects builds where JS and CSS entries share the same base name
- **Backward compatible**: Single CSS entries (like `entry: 'index.css'`) behave exactly as before
- **All existing tests pass**: No snapshot updates needed

## Test Cases

| Scenario | Behavior |
|----------|----------|
| CSS-only entry (no conflict) | ✅ Unchanged - generates `index.mjs` (empty) + `index.css` |
| JS + CSS same name entries | ✅ Fixed - both `index.js` and `index.css` output correctly |
| Multiple CSS entries | ✅ Unchanged - `foo.mjs`, `bar.mjs`, `foo.css`, `bar.css` |
| JS imports CSS | ✅ Works - CSS extracted, import preserved if needed |

## Changes

- `src/features/entry.ts` - Detect naming conflicts and add `.css` suffix for CSS entries when needed
- `src/features/css.ts` - Add `CssEntryPlugin` to clean up conflict outputs
- `src/features/rolldown.ts` - Register the new plugin

## Related

- Issue: https://github.com/rolldown/tsdown/issues/627
- This is a workaround for Rolldown's behavior. A native fix in Rolldown would be the ideal solution.