### PR TITLE
fix: print blank line only when the log level is info.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,9 @@ export async function buildSingle(
 
         case 'BUNDLE_START': {
           if (changedFile.length > 0) {
-            console.info('')
+            if (logger.level === 'info') {
+              console.info('')
+            }
             logger.info(
               `Found ${bold(changedFile.join(', '))} changed, rebuilding...`,
             )


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.

-->

- [ x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Based on several plugins written for tsdown, when the tsdown log level is set to silent, an extra line break still appears. After investigation, it was found to be caused by the line of code console.info('').

https://github.com/rolldown/tsdown/blob/ef0772336549deedd8c53f94a57fb055cbc69d01/src/index.ts#L209

https://github.com/tomjs/vite-plugin-vscode/blob/main/src/index.ts#L280-L285

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
