### PR TITLE
Use a compatible version of dirname

### DIFF
--- a/src/features/shims.ts
+++ b/src/features/shims.ts
@@ -1,8 +1,11 @@
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import type { NormalizedFormat, ResolvedConfig } from '../config/index.ts'
 
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+
 export const shimFile: string = path.resolve(
-  import.meta.dirname,
+  dirname,
   import.meta.TSDOWN_PRODUCTION ? '..' : '../..',
   'esm-shims.js',
 )


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.

-->

- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

When I use `tsx` to execute the `build` API, `tsx` does not support `import.meta.dirname`; could we adopt a compatible writing style instead?


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
