### PR TITLE
docs: enhance documentation with entries, CI, lint, and sourcemap

### DIFF
--- a/docs/.vitepress/config/theme.ts
+++ b/docs/.vitepress/config/theme.ts
@@ -110,6 +110,7 @@ export function getLocaleConfig(lang: string) {
         { text: t('Unbundle'), link: '/unbundle.md' },
         { text: t('CJS Default Export'), link: '/cjs-default.md' },
         { text: t('CSS'), link: '/css.md' },
+        { text: t('Package Validation'), link: '/lint.md' },
       ],
     },
     {
@@ -130,6 +131,7 @@ export function getLocaleConfig(lang: string) {
         { text: t('Hooks'), link: '/hooks.md' },
         { text: t('Rolldown Options'), link: '/rolldown-options.md' },
         { text: t('Programmatic Usage'), link: '/programmatic-usage.md' },
+        { text: t('CI Environment'), link: '/ci.md' },
         { text: t('Benchmark'), link: '/benchmark.md' },
       ],
     },

--- a/docs/.vitepress/i18n/translate-map.ts
+++ b/docs/.vitepress/i18n/translate-map.ts
@@ -28,6 +28,7 @@ const zhCN = {
   'Package Exports': '包导出（Package Exports）',
   Unbundle: '非打包模式（Unbundle）',
   'CJS Default Export': 'CJS 默认导出',
+  'Package Validation': '包校验',
 
   Recipes: '实践指南',
   'Vue Support': 'Vue 支持',
@@ -40,6 +41,7 @@ const zhCN = {
   Plugins: '插件',
   Hooks: '钩子（Hooks）',
   'Programmatic Usage': '编程使用',
+  'CI Environment': 'CI 环境',
   Benchmark: '性能基准',
   FAQ: '常见问题',
   'Work with AI': '与 AI 协作',

--- a/docs/advanced/ci.md
+++ b/docs/advanced/ci.md
@@ -1,0 +1,99 @@
+# CI Environment Support
+
+tsdown automatically detects CI environments and allows you to enable or disable specific features depending on whether the build runs locally or in CI.
+
+## CI Detection
+
+tsdown uses the [`is-in-ci`](https://www.npmjs.com/package/is-in-ci) package to detect CI environments. This covers all major CI providers including GitHub Actions, GitLab CI, Jenkins, CircleCI, Travis CI, and more.
+
+## CI-Aware Options
+
+Several options support CI-aware behavior through the `'ci-only'` and `'local-only'` values:
+
+| Value          | Behavior                             |
+| -------------- | ------------------------------------ |
+| `true`         | Always enabled                       |
+| `false`        | Always disabled                      |
+| `'ci-only'`    | Enabled only in CI, disabled locally |
+| `'local-only'` | Enabled only locally, disabled in CI |
+
+### Supported Options
+
+The following options accept CI-aware values:
+
+- [`dts`](/options/dts) — TypeScript declaration file generation
+- [`publint`](/options/lint) — Package lint validation
+- [`attw`](/options/lint) — "Are the types wrong" validation
+- `report` — Bundle size reporting
+- [`exports`](/options/package-exports) — Auto-generate `package.json` exports
+- `unused` — Unused dependency check
+- `devtools` — DevTools integration
+- `failOnWarn` — Fail on warnings (defaults to `'ci-only'`)
+
+### Basic Usage
+
+Pass a CI option string directly:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  // Only generate declaration files locally (skip in CI for faster builds)
+  dts: 'local-only',
+  // Only run publint in CI
+  publint: 'ci-only',
+  // Fail on warnings in CI only (this is the default)
+  failOnWarn: 'ci-only',
+})
+```
+
+### Object Form
+
+When an option takes a configuration object, you can set the `enabled` property to a CI-aware value:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  publint: {
+    enabled: 'ci-only',
+    level: 'error',
+  },
+  attw: {
+    enabled: 'ci-only',
+    profile: 'node16',
+  },
+})
+```
+
+## Config Function
+
+The config function receives a `ci` boolean in its context, allowing dynamic configuration:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig((_, { ci }) => ({
+  minify: ci,
+  sourcemap: !ci,
+}))
+```
+
+## Example: CI Pipeline
+
+A typical CI-optimized configuration:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: 'src/index.ts',
+  format: ['esm', 'cjs'],
+  dts: true,
+  // Fail on warnings in CI
+  failOnWarn: 'ci-only',
+  // Run package validators in CI
+  publint: 'ci-only',
+  attw: 'ci-only',
+})
+```

--- a/docs/options/entry.md
+++ b/docs/options/entry.md
@@ -71,6 +71,89 @@ export default defineConfig({
 
 This configuration will include all `.ts` files in the `src` directory and its subdirectories as entry points.
 
+You can also use glob patterns in arrays, with negation patterns to exclude specific files:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/*.ts', '!src/*.test.ts'],
+})
+```
+
+### Object Entries with Glob Patterns
+
+When using the object form, you can use glob wildcards (`*`) in both keys and values. The `*` in the key acts as a placeholder that gets replaced with the matched file name (without extension):
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    // Maps src/foo.ts → dist/lib/foo.js, src/bar.ts → dist/lib/bar.js
+    'lib/*': 'src/*.ts',
+  },
+})
+```
+
+This is useful for creating output structures that differ from the source layout.
+
+#### Negation Patterns
+
+When using glob keys, values can be an array of patterns including negation patterns (prefixed with `!`) to exclude specific files:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    // Include all hooks except the index file
+    'hooks/*': ['src/hooks/*.ts', '!src/hooks/index.ts'],
+  },
+})
+```
+
+#### Multiple Patterns
+
+You can combine multiple positive patterns and multiple negation patterns:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    'utils/*': [
+      'src/utils/*.ts',
+      'src/utils/*.tsx',
+      '!src/utils/index.ts',
+      '!src/utils/internal.ts',
+    ],
+  },
+})
+```
+
+> [!WARNING]
+> When using multiple positive patterns in an array value, all patterns must share the same base directory. For example, mixing `src/hooks/*.ts` and `src/utils/*.ts` in a single entry key will throw an error.
+
+#### Mixed Entries
+
+You can mix strings, glob patterns, and object entries in an array:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: [
+    'src/*',
+    '!src/foo.ts',
+    { main: 'index.ts' },
+    { 'lib/*': ['src/*.ts', '!src/bar.ts'] },
+  ],
+})
+```
+
+When the same output name appears in both array entries and object entries, the object entry takes precedence.
+
 > [!TIP]
 >
 > On **Windows**, you must use forward slashes (`/`) instead of backslashes (`\`) in file paths when using glob patterns.

--- a/docs/options/lint.md
+++ b/docs/options/lint.md
@@ -1,0 +1,146 @@
+# Package Validation (publint & attw)
+
+tsdown integrates with [publint](https://publint.dev/) and [Are the types wrong?](https://arethetypeswrong.github.io/) (attw) to validate your package before publishing. These tools check for common issues in your `package.json` configuration and type definitions.
+
+## Installation
+
+Both tools are **optional dependencies** — you only need to install them if you want to use them:
+
+::: code-group
+
+```bash [publint]
+npm install -D publint
+```
+
+```bash [attw]
+npm install -D @arethetypeswrong/core
+```
+
+```bash [both]
+npm install -D publint @arethetypeswrong/core
+```
+
+:::
+
+## publint
+
+[publint](https://publint.dev/) checks that your package is correctly configured for publishing. It validates `package.json` fields like `exports`, `main`, `module`, and `types` against your actual output files.
+
+### Enable publint
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  publint: true,
+})
+```
+
+### Configuration
+
+Pass options directly to customize publint's behavior:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  publint: {
+    level: 'error', // 'warning' | 'error' | 'suggestion'
+  },
+})
+```
+
+### CLI
+
+```bash
+tsdown --publint
+```
+
+## attw (Are the types wrong?)
+
+[attw](https://arethetypeswrong.github.io/) verifies that your TypeScript declaration files are correct across different module resolution strategies (`node10`, `node16`, `bundler`). It catches issues like false ESM/CJS type declarations that can cause runtime errors for consumers.
+
+### Enable attw
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  attw: true,
+})
+```
+
+### Configuration
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  attw: {
+    // Resolution profile:
+    //   'strict'   - requires all resolutions (default)
+    //   'node16'   - ignores node10 resolution failures
+    //   'esm-only' - ignores CJS resolution failures
+    profile: 'node16',
+
+    // Level: 'warn' (default) or 'error' (fails the build)
+    level: 'error',
+
+    // Ignore specific problem types
+    ignoreRules: ['false-cjs', 'cjs-resolves-to-esm'],
+  },
+})
+```
+
+### Profiles
+
+| Profile    | Description                                           |
+| ---------- | ----------------------------------------------------- |
+| `strict`   | Requires all resolutions to pass (default)            |
+| `node16`   | Ignores `node10` resolution failures                  |
+| `esm-only` | Ignores `node10` and `node16-cjs` resolution failures |
+
+### Ignore Rules
+
+You can suppress specific problem types using `ignoreRules`:
+
+| Rule                        | Description                                             |
+| --------------------------- | ------------------------------------------------------- |
+| `no-resolution`             | Module could not be resolved                            |
+| `untyped-resolution`        | Resolution succeeded but has no types                   |
+| `false-cjs`                 | Types indicate CJS but implementation is ESM            |
+| `false-esm`                 | Types indicate ESM but implementation is CJS            |
+| `cjs-resolves-to-esm`       | CJS resolution points to an ESM module                  |
+| `fallback-condition`        | A fallback/wildcard condition was used                  |
+| `cjs-only-exports-default`  | CJS module only exports a default                       |
+| `named-exports`             | Named exports mismatch between types and implementation |
+| `false-export-default`      | Types declare a default export that doesn't exist       |
+| `missing-export-equals`     | Types are missing `export =` for CJS                    |
+| `unexpected-module-syntax`  | File uses unexpected module syntax                      |
+| `internal-resolution-error` | Internal resolution error in type checking              |
+
+### CLI
+
+```bash
+tsdown --attw
+```
+
+## CI Integration
+
+Both `publint` and `attw` support [CI-aware options](/advanced/ci). This is useful for running package validation only in CI:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  publint: 'ci-only',
+  attw: {
+    enabled: 'ci-only',
+    profile: 'node16',
+    level: 'error',
+  },
+})
+```
+
+> [!NOTE]
+> Both tools require a `package.json` in your project directory. If no `package.json` is found, a warning is logged and the check is skipped.

--- a/docs/options/log-level.md
+++ b/docs/options/log-level.md
@@ -26,3 +26,24 @@ This is useful for CI/CD pipelines or scenarios where you want minimal or no con
 - `info`: Informational messages, warnings, and errors are logged (default).
 
 Choose the log level that best fits your workflow to control the amount of information displayed during the build process.
+
+## Fail on Warnings
+
+The `failOnWarn` option controls whether warnings cause the build to exit with a non-zero code. By default, this is set to `'ci-only'`, which means **warnings will cause the build to fail in CI environments** but not locally.
+
+This default behavior ensures that CI pipelines catch potential issues while keeping local development uninterrupted.
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  // Default: fail on warnings only in CI
+  failOnWarn: 'ci-only',
+  // Always fail on warnings
+  // failOnWarn: true,
+  // Never fail on warnings
+  // failOnWarn: false,
+})
+```
+
+See [CI Environment](/advanced/ci) for more about CI-aware options.

--- a/docs/options/sourcemap.md
+++ b/docs/options/sourcemap.md
@@ -4,7 +4,7 @@ Source maps bridge the gap between your original development code and the optimi
 
 For example, source maps enable you to identify which line in your React or Vue component caused an error, even though the runtime environment only sees the bundled or minified code.
 
-### Enabling Source Maps
+## Enabling Source Maps
 
 You can instruct `tsdown` to generate source maps by using the `--sourcemap` option:
 
@@ -12,4 +12,59 @@ You can instruct `tsdown` to generate source maps by using the `--sourcemap` opt
 tsdown --sourcemap
 ```
 
-Note that source maps will always be enabled if you have [`declarationMap`](https://www.typescriptlang.org/tsconfig/#declarationMap) option enabled in your `tsconfig.json`.
+Or in the config file:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  sourcemap: true,
+})
+```
+
+> [!NOTE]
+> Source maps will always be enabled if you have [`declarationMap`](https://www.typescriptlang.org/tsconfig/#declarationMap) option enabled in your `tsconfig.json`.
+
+## Source Map Modes
+
+The `sourcemap` option accepts the following values:
+
+| Value      | Description                                                                                                                                                                                                                         |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `false`    | Disable source maps (default)                                                                                                                                                                                                       |
+| `true`     | Generate separate `.map` files alongside the output. A `//# sourceMappingURL` comment is appended to each output file pointing to the `.map` file.                                                                                  |
+| `'inline'` | Embed the source map directly in the output file as a base64-encoded data URL. No separate `.map` file is generated. Similar to TypeScript's [`inlineSourceMap`](https://www.typescriptlang.org/tsconfig/#inlineSourceMap).         |
+| `'hidden'` | Generate separate `.map` files but **do not** append the `//# sourceMappingURL` comment to the output. Useful when you want source maps available for error monitoring services but don't want browsers to load them automatically. |
+
+### Using the CLI
+
+```bash
+# Enable source maps (separate .map files)
+tsdown --sourcemap
+
+# Inline source maps
+tsdown --sourcemap inline
+
+# Hidden source maps
+tsdown --sourcemap hidden
+```
+
+### Using the Config File
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  // Inline source maps into output files
+  sourcemap: 'inline',
+})
+```
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  // Generate .map files without sourceMappingURL comments
+  sourcemap: 'hidden',
+})
+```

--- a/docs/zh-CN/advanced/ci.md
+++ b/docs/zh-CN/advanced/ci.md
@@ -1,0 +1,99 @@
+# CI 环境支持
+
+tsdown 能够自动检测 CI 环境，并允许你根据构建是在本地还是在 CI 中运行来启用或禁用特定功能。
+
+## CI 检测
+
+tsdown 使用 [`is-in-ci`](https://www.npmjs.com/package/is-in-ci) 包来检测 CI 环境，支持所有主流 CI 服务商，包括 GitHub Actions、GitLab CI、Jenkins、CircleCI、Travis CI 等。
+
+## CI 感知选项
+
+多个选项支持通过 `'ci-only'` 和 `'local-only'` 值实现 CI 感知行为：
+
+| 值             | 行为                     |
+| -------------- | ------------------------ |
+| `true`         | 始终启用                 |
+| `false`        | 始终禁用                 |
+| `'ci-only'`    | 仅在 CI 中启用，本地禁用 |
+| `'local-only'` | 仅在本地启用，CI 中禁用  |
+
+### 支持的选项
+
+以下选项接受 CI 感知值：
+
+- [`dts`](/zh-CN/options/dts) — TypeScript 声明文件生成
+- [`publint`](/zh-CN/options/lint) — 包规范校验
+- [`attw`](/zh-CN/options/lint) — "Are the types wrong" 类型校验
+- `report` — 构建产物体积报告
+- [`exports`](/zh-CN/options/package-exports) — 自动生成 `package.json` exports 字段
+- `unused` — 未使用依赖检查
+- `devtools` — DevTools 集成
+- `failOnWarn` — 遇警告时失败（默认值为 `'ci-only'`）
+
+### 基本用法
+
+直接传递 CI 选项字符串：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  // 仅在本地生成声明文件（CI 中跳过以加快构建速度）
+  dts: 'local-only',
+  // 仅在 CI 中运行 publint
+  publint: 'ci-only',
+  // 仅在 CI 中遇警告时失败（这是默认行为）
+  failOnWarn: 'ci-only',
+})
+```
+
+### 对象形式
+
+当选项接受配置对象时，可以将 `enabled` 属性设置为 CI 感知值：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  publint: {
+    enabled: 'ci-only',
+    level: 'error',
+  },
+  attw: {
+    enabled: 'ci-only',
+    profile: 'node16',
+  },
+})
+```
+
+## 配置函数
+
+配置函数在其上下文中接收 `ci` 布尔值，允许动态配置：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig((_, { ci }) => ({
+  minify: ci,
+  sourcemap: !ci,
+}))
+```
+
+## 示例：CI 流水线
+
+一个典型的 CI 优化配置：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: 'src/index.ts',
+  format: ['esm', 'cjs'],
+  dts: true,
+  // 在 CI 中遇警告时失败
+  failOnWarn: 'ci-only',
+  // 在 CI 中运行包校验工具
+  publint: 'ci-only',
+  attw: 'ci-only',
+})
+```

--- a/docs/zh-CN/options/entry.md
+++ b/docs/zh-CN/options/entry.md
@@ -71,6 +71,89 @@ export default defineConfig({
 
 此配置会将 `src` 目录及其子目录中的所有 `.ts` 文件作为入口点。
 
+在数组中也可以使用 glob 模式，并通过否定模式排除特定文件：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/*.ts', '!src/*.test.ts'],
+})
+```
+
+### 对象入口与 Glob 模式
+
+使用对象形式时，键和值都可以使用 glob 通配符（`*`）。键中的 `*` 会被匹配到的文件名（不含扩展名）替换：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    // 将 src/foo.ts → dist/lib/foo.js，src/bar.ts → dist/lib/bar.js
+    'lib/*': 'src/*.ts',
+  },
+})
+```
+
+这在需要输出结构与源码目录结构不同时非常有用。
+
+#### 否定模式
+
+使用 glob 键时，值可以是一个模式数组，包含否定模式（以 `!` 为前缀）来排除特定文件：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    // 包含所有 hooks，但排除 index 文件
+    'hooks/*': ['src/hooks/*.ts', '!src/hooks/index.ts'],
+  },
+})
+```
+
+#### 多模式组合
+
+可以同时组合多个匹配模式和多个否定模式：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    'utils/*': [
+      'src/utils/*.ts',
+      'src/utils/*.tsx',
+      '!src/utils/index.ts',
+      '!src/utils/internal.ts',
+    ],
+  },
+})
+```
+
+> [!WARNING]
+> 在数组值中使用多个匹配模式时，所有模式必须具有相同的基础目录。例如，在同一个入口键中混合 `src/hooks/*.ts` 和 `src/utils/*.ts` 会抛出错误。
+
+#### 混合入口
+
+可以在数组中混合使用字符串、glob 模式和对象入口：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: [
+    'src/*',
+    '!src/foo.ts',
+    { main: 'index.ts' },
+    { 'lib/*': ['src/*.ts', '!src/bar.ts'] },
+  ],
+})
+```
+
+当数组入口和对象入口出现相同的输出名时，对象入口优先。
+
 > [!TIP]
 >
 > 在 **Windows** 系统中，使用通配符模式（glob pattern）时，文件路径必须使用正斜杠（`/`），而不能使用反斜杠（`\`）。

--- a/docs/zh-CN/options/lint.md
+++ b/docs/zh-CN/options/lint.md
@@ -1,0 +1,146 @@
+# 包校验（publint 和 attw）
+
+tsdown 集成了 [publint](https://publint.dev/) 和 [Are the types wrong?](https://arethetypeswrong.github.io/)（attw），用于在发布前校验你的包。这些工具可以检查 `package.json` 配置和类型定义中的常见问题。
+
+## 安装
+
+两个工具都是**可选依赖** —— 仅在需要使用时安装：
+
+::: code-group
+
+```bash [publint]
+npm install -D publint
+```
+
+```bash [attw]
+npm install -D @arethetypeswrong/core
+```
+
+```bash [同时安装]
+npm install -D publint @arethetypeswrong/core
+```
+
+:::
+
+## publint
+
+[publint](https://publint.dev/) 检查你的包是否正确配置以供发布。它会验证 `package.json` 中的 `exports`、`main`、`module`、`types` 等字段与实际输出文件是否一致。
+
+### 启用 publint
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  publint: true,
+})
+```
+
+### 配置
+
+直接传递选项来自定义 publint 的行为：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  publint: {
+    level: 'error', // 'warning' | 'error' | 'suggestion'
+  },
+})
+```
+
+### CLI
+
+```bash
+tsdown --publint
+```
+
+## attw（Are the types wrong?）
+
+[attw](https://arethetypeswrong.github.io/) 验证你的 TypeScript 声明文件在不同模块解析策略（`node10`、`node16`、`bundler`）下是否正确。它能捕获错误的 ESM/CJS 类型声明等问题，这些问题可能导致使用者遇到运行时错误。
+
+### 启用 attw
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  attw: true,
+})
+```
+
+### 配置
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  attw: {
+    // 解析配置：
+    //   'strict'   - 要求所有解析方式通过（默认）
+    //   'node16'   - 忽略 node10 解析失败
+    //   'esm-only' - 忽略 CJS 解析失败
+    profile: 'node16',
+
+    // 级别：'warn'（默认）或 'error'（导致构建失败）
+    level: 'error',
+
+    // 忽略特定的问题类型
+    ignoreRules: ['false-cjs', 'cjs-resolves-to-esm'],
+  },
+})
+```
+
+### 配置（Profiles）
+
+| 配置       | 说明                                   |
+| ---------- | -------------------------------------- |
+| `strict`   | 要求所有解析方式通过（默认）           |
+| `node16`   | 忽略 `node10` 解析失败                 |
+| `esm-only` | 忽略 `node10` 和 `node16-cjs` 解析失败 |
+
+### 忽略规则
+
+你可以通过 `ignoreRules` 来抑制特定的问题类型：
+
+| 规则                        | 说明                        |
+| --------------------------- | --------------------------- |
+| `no-resolution`             | 模块无法解析                |
+| `untyped-resolution`        | 解析成功但没有类型          |
+| `false-cjs`                 | 类型标注为 CJS 但实现是 ESM |
+| `false-esm`                 | 类型标注为 ESM 但实现是 CJS |
+| `cjs-resolves-to-esm`       | CJS 解析指向 ESM 模块       |
+| `fallback-condition`        | 使用了 fallback/通配符条件  |
+| `cjs-only-exports-default`  | CJS 模块仅导出默认值        |
+| `named-exports`             | 类型与实现的命名导出不匹配  |
+| `false-export-default`      | 类型声明了不存在的默认导出  |
+| `missing-export-equals`     | CJS 类型缺少 `export =`     |
+| `unexpected-module-syntax`  | 文件使用了意外的模块语法    |
+| `internal-resolution-error` | 类型检查中的内部解析错误    |
+
+### CLI
+
+```bash
+tsdown --attw
+```
+
+## CI 集成
+
+`publint` 和 `attw` 都支持 [CI 感知选项](/zh-CN/advanced/ci)。这适用于仅在 CI 中运行包校验：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  publint: 'ci-only',
+  attw: {
+    enabled: 'ci-only',
+    profile: 'node16',
+    level: 'error',
+  },
+})
+```
+
+> [!NOTE]
+> 两个工具都需要项目目录中存在 `package.json`。如果未找到 `package.json`，会记录警告并跳过检查。

--- a/docs/zh-CN/options/log-level.md
+++ b/docs/zh-CN/options/log-level.md
@@ -26,3 +26,24 @@ tsdown --log-level error
 - `info`：显示信息、警告和错误（默认）。
 
 根据您的工作流选择合适的日志级别，以控制构建过程中显示的信息量。
+
+## 警告时失败
+
+`failOnWarn` 选项控制警告是否会导致构建以非零退出码退出。默认值为 `'ci-only'`，这意味着**在 CI 环境中，警告会导致构建失败**，但在本地开发时不会。
+
+这种默认行为确保 CI 流水线能够发现潜在问题，同时不会影响本地开发体验。
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  // 默认：仅在 CI 中遇警告时失败
+  failOnWarn: 'ci-only',
+  // 始终在遇到警告时失败
+  // failOnWarn: true,
+  // 从不在遇到警告时失败
+  // failOnWarn: false,
+})
+```
+
+详见 [CI 环境](/zh-CN/advanced/ci) 了解更多 CI 感知选项。

--- a/docs/zh-CN/options/sourcemap.md
+++ b/docs/zh-CN/options/sourcemap.md
@@ -4,7 +4,7 @@
 
 例如，源映射可以帮助您定位 React 或 Vue 组件中导致错误的具体代码行，即使运行环境只能看到打包或压缩后的代码。
 
-### 启用源映射
+## 启用源映射
 
 您可以通过使用 `--sourcemap` 选项指示 `tsdown` 生成源映射：
 
@@ -12,4 +12,59 @@
 tsdown --sourcemap
 ```
 
-请注意，如果您在 `tsconfig.json` 中启用了 [`declarationMap`](https://www.typescriptlang.org/tsconfig/#declarationMap) 选项，则 source map 将始终启用。
+或在配置文件中：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  sourcemap: true,
+})
+```
+
+> [!NOTE]
+> 如果您在 `tsconfig.json` 中启用了 [`declarationMap`](https://www.typescriptlang.org/tsconfig/#declarationMap) 选项，则 source map 将始终启用。
+
+## Source Map 模式
+
+`sourcemap` 选项接受以下值：
+
+| 值         | 说明                                                                                                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `false`    | 禁用源映射（默认）                                                                                                                                                                         |
+| `true`     | 在输出文件旁生成独立的 `.map` 文件。输出文件末尾会附加 `//# sourceMappingURL` 注释指向 `.map` 文件。                                                                                       |
+| `'inline'` | 将源映射以 base64 编码的 data URL 形式直接嵌入输出文件中。不会生成独立的 `.map` 文件。类似于 TypeScript 的 [`inlineSourceMap`](https://www.typescriptlang.org/tsconfig/#inlineSourceMap)。 |
+| `'hidden'` | 生成独立的 `.map` 文件，但**不**在输出文件末尾附加 `//# sourceMappingURL` 注释。适用于希望为错误监控服务提供源映射，但不希望浏览器自动加载的场景。                                         |
+
+### 使用 CLI
+
+```bash
+# 启用源映射（生成独立的 .map 文件）
+tsdown --sourcemap
+
+# 内联源映射
+tsdown --sourcemap inline
+
+# 隐藏源映射
+tsdown --sourcemap hidden
+```
+
+### 使用配置文件
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  // 将源映射内联到输出文件中
+  sourcemap: 'inline',
+})
+```
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  // 生成 .map 文件但不添加 sourceMappingURL 注释
+  sourcemap: 'hidden',
+})
+```


### PR DESCRIPTION
## Description

This PR enhances the documentation across multiple features:

- **Object entries with glob support** — Added comprehensive docs for glob patterns with negation, wildcard keys, multiple patterns, and mixed entry types
- **CI environment support** — New advanced guide documenting CI-aware options (`ci-only`, `local-only`), including failOnWarn behavior that fails CI builds on warnings by default
- **Package linting integration** — New options guide for publint and attw with installation instructions, configuration examples, profiles, and ignore rules
- **Sourcemap enhancements** — Updated sourcemap documentation with CLI usage examples for all three modes (inline, hidden, separate)
- **Log level enhancements** — Added failOnWarn section to explain default CI-only behavior

All documentation is provided in both English and Chinese with consistent translations.

## Linked Issues

Resolves (don't close) #247 (Documentation Request):
- [x] object entries with glob support
- [x] CI
- [x] publint / attw

Resolves #442 (Sourcemap documentation)
- Enhanced with all three modes and CLI examples

## Additional context

The failOnWarn default of `'ci-only'` is an important behavior that may surprise new users when warnings cause CI to fail. This PR ensures that's documented clearly in the log-level docs with a cross-reference to the CI environment guide for more context.