### PR TITLE
docs: add WASM support guide

### DIFF
--- a/docs/.vitepress/config/theme.ts
+++ b/docs/.vitepress/config/theme.ts
@@ -121,6 +121,7 @@ export function getLocaleConfig(lang: string) {
         { text: t('React Support'), link: '/react-support.md' },
         { text: t('Solid Support'), link: '/solid-support.md' },
         { text: t('Svelte Support'), link: '/svelte-support.md' },
+        { text: t('WASM Support'), link: '/wasm-support.md' },
       ],
     },
     {

--- a/docs/.vitepress/i18n/translate-map.ts
+++ b/docs/.vitepress/i18n/translate-map.ts
@@ -35,6 +35,7 @@ const zhCN = {
   'React Support': 'React 支持',
   'Solid Support': 'Solid 支持',
   'Svelte Support': 'Svelte 支持',
+  'WASM Support': 'WASM 支持',
 
   Advanced: '高级功能',
   'Rolldown Options': 'Rolldown 选项',

--- a/docs/recipes/wasm-support.md
+++ b/docs/recipes/wasm-support.md
@@ -1,0 +1,151 @@
+# WASM Support
+
+`tsdown` supports bundling WebAssembly (WASM) modules through [`rolldown-plugin-wasm`](https://github.com/sxzz/rolldown-plugin-wasm). This plugin allows you to import `.wasm` files directly in your TypeScript or JavaScript code, with support for both synchronous and asynchronous instantiation.
+
+## Minimal Example
+
+To configure `tsdown` for WASM support, add the plugin to your `tsdown.config.ts`:
+
+```ts [tsdown.config.ts]
+import { wasm } from 'rolldown-plugin-wasm'
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  plugins: [wasm()],
+})
+```
+
+Install the required dependency:
+
+::: code-group
+
+```sh [npm]
+npm install -D rolldown-plugin-wasm
+```
+
+```sh [pnpm]
+pnpm add -D rolldown-plugin-wasm
+```
+
+```sh [yarn]
+yarn add -D rolldown-plugin-wasm
+```
+
+```sh [bun]
+bun add -D rolldown-plugin-wasm
+```
+
+:::
+
+## Importing WASM Modules
+
+You can import WASM modules directly:
+
+```ts
+import { add } from './add.wasm'
+
+add(1, 2)
+```
+
+### Asynchronous Init
+
+Use the `?init` query to get an async initialization function:
+
+```ts
+import init from './add.wasm?init'
+
+const instance = await init(
+  imports, // optional
+)
+
+instance.exports.add(1, 2)
+```
+
+### Synchronous Init
+
+Use the `?init&sync` query for synchronous initialization:
+
+```ts
+import initSync from './add.wasm?init&sync'
+
+const instance = initSync(
+  imports, // optional
+)
+
+instance.exports.add(1, 2)
+```
+
+## `wasm-bindgen` Support
+
+### Target `bundler` (Default, Recommended)
+
+```ts
+import { add } from 'some-pkg'
+
+add(1, 2)
+```
+
+### Target `web`
+
+#### Node.js
+
+```ts
+import { readFile } from 'node:fs/promises'
+import init, { add } from 'some-pkg'
+import wasmUrl from 'some-pkg/add_bg.wasm?url'
+
+await init({
+  module_or_path: readFile(new URL(wasmUrl, import.meta.url)),
+})
+
+add(1, 2)
+```
+
+#### Browser
+
+```ts
+import init, { add } from 'some-pkg/add.js'
+import wasmUrl from 'some-pkg/add_bg.wasm?url'
+
+await init({
+  module_or_path: wasmUrl,
+})
+
+add(1, 2)
+```
+
+> [!NOTE]
+> Other `wasm-bindgen` targets such as `nodejs` and `no-modules` are not supported.
+
+## TypeScript Support
+
+To get type support for `.wasm` imports, add the type declarations to your `tsconfig.json`:
+
+```jsonc [tsconfig.json]
+{
+  "compilerOptions": {
+    "types": ["rolldown-plugin-wasm/types"],
+  },
+}
+```
+
+## Options
+
+The plugin accepts an options object:
+
+```ts
+wasm({
+  maxFileSize: 14 * 1024, // Max file size for inline (default: 14KB)
+  fileName: '[hash][extname]', // Output file name pattern
+  publicPath: '', // Prefix for non-inlined file paths
+  targetEnv: 'auto', // 'auto' | 'auto-inline' | 'browser' | 'node'
+})
+```
+
+| Option        | Default             | Description                                                                                                                                                                                                                                      |
+| ------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `maxFileSize` | `14 * 1024`         | Maximum file size for inlining. Files exceeding this limit are copied to the output directory and loaded at runtime. Set to `0` to always copy.                                                                                                  |
+| `fileName`    | `'[hash][extname]'` | Pattern for renaming emitted WASM files.                                                                                                                                                                                                         |
+| `publicPath`  | —                   | Prefix added to file paths for non-inlined WASM files.                                                                                                                                                                                           |
+| `targetEnv`   | `'auto'`            | Controls the generated instantiation code. `'auto'` detects the environment at runtime; `'auto-inline'` always inlines and decodes based on environment; `'browser'` omits Node.js builtins; `'node'` omits `fetch` (requires Node.js 20.16.0+). |

--- a/docs/zh-CN/recipes/wasm-support.md
+++ b/docs/zh-CN/recipes/wasm-support.md
@@ -1,0 +1,151 @@
+# WASM 支持
+
+`tsdown` 通过 [`rolldown-plugin-wasm`](https://github.com/sxzz/rolldown-plugin-wasm) 支持打包 WebAssembly（WASM）模块。该插件允许您在 TypeScript 或 JavaScript 代码中直接导入 `.wasm` 文件，同时支持同步和异步实例化。
+
+## 最简示例
+
+要配置 `tsdown` 支持 WASM，请在 `tsdown.config.ts` 中添加该插件：
+
+```ts [tsdown.config.ts]
+import { wasm } from 'rolldown-plugin-wasm'
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  plugins: [wasm()],
+})
+```
+
+安装所需依赖：
+
+::: code-group
+
+```sh [npm]
+npm install -D rolldown-plugin-wasm
+```
+
+```sh [pnpm]
+pnpm add -D rolldown-plugin-wasm
+```
+
+```sh [yarn]
+yarn add -D rolldown-plugin-wasm
+```
+
+```sh [bun]
+bun add -D rolldown-plugin-wasm
+```
+
+:::
+
+## 导入 WASM 模块
+
+您可以直接导入 WASM 模块：
+
+```ts
+import { add } from './add.wasm'
+
+add(1, 2)
+```
+
+### 异步初始化
+
+使用 `?init` 查询参数获取异步初始化函数：
+
+```ts
+import init from './add.wasm?init'
+
+const instance = await init(
+  imports, // 可选
+)
+
+instance.exports.add(1, 2)
+```
+
+### 同步初始化
+
+使用 `?init&sync` 查询参数进行同步初始化：
+
+```ts
+import initSync from './add.wasm?init&sync'
+
+const instance = initSync(
+  imports, // 可选
+)
+
+instance.exports.add(1, 2)
+```
+
+## `wasm-bindgen` 支持
+
+### 目标 `bundler`（默认，推荐）
+
+```ts
+import { add } from 'some-pkg'
+
+add(1, 2)
+```
+
+### 目标 `web`
+
+#### Node.js
+
+```ts
+import { readFile } from 'node:fs/promises'
+import init, { add } from 'some-pkg'
+import wasmUrl from 'some-pkg/add_bg.wasm?url'
+
+await init({
+  module_or_path: readFile(new URL(wasmUrl, import.meta.url)),
+})
+
+add(1, 2)
+```
+
+#### 浏览器
+
+```ts
+import init, { add } from 'some-pkg/add.js'
+import wasmUrl from 'some-pkg/add_bg.wasm?url'
+
+await init({
+  module_or_path: wasmUrl,
+})
+
+add(1, 2)
+```
+
+> [!NOTE]
+> 不支持其他 `wasm-bindgen` 目标，如 `nodejs` 和 `no-modules`。
+
+## TypeScript 支持
+
+要获得 `.wasm` 导入的类型支持，请在 `tsconfig.json` 中添加类型声明：
+
+```jsonc [tsconfig.json]
+{
+  "compilerOptions": {
+    "types": ["rolldown-plugin-wasm/types"],
+  },
+}
+```
+
+## 选项
+
+该插件接受一个选项对象：
+
+```ts
+wasm({
+  maxFileSize: 14 * 1024, // 内联的最大文件大小（默认：14KB）
+  fileName: '[hash][extname]', // 输出文件名模式
+  publicPath: '', // 非内联文件路径前缀
+  targetEnv: 'auto', // 'auto' | 'auto-inline' | 'browser' | 'node'
+})
+```
+
+| 选项          | 默认值              | 说明                                                                                                                                                                         |
+| ------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxFileSize` | `14 * 1024`         | 内联的最大文件大小。超过此限制的文件将被复制到输出目录并在运行时加载。设为 `0` 表示始终复制。                                                                                |
+| `fileName`    | `'[hash][extname]'` | 生成的 WASM 文件的命名模式。                                                                                                                                                 |
+| `publicPath`  | —                   | 非内联 WASM 文件路径的前缀。                                                                                                                                                 |
+| `targetEnv`   | `'auto'`            | 控制生成的实例化代码。`'auto'` 在运行时检测环境；`'auto-inline'` 始终内联并根据环境解码；`'browser'` 省略 Node.js 内置模块；`'node'` 省略 `fetch`（需要 Node.js 20.16.0+）。 |


### PR DESCRIPTION
Adds comprehensive WASM support documentation for tsdown, including configuration, import patterns, and TypeScript setup. Covers both direct WASM imports and `wasm-bindgen` support with synchronous and asynchronous initialization examples.

**Fixes #676**

- [x] Documentation (AI-generated but reviewed)

### Description

Added new recipe pages for WASM support in both English and Chinese:
- Configuration examples with `rolldown-plugin-wasm`
- Import patterns (direct, async init, sync init)
- `wasm-bindgen` support (bundler and web targets)
- TypeScript type setup
- Complete plugin options reference

### Linked Issues

Resolves #676 from documentation tasks in #247