### PR TITLE
fix: throw error when skipNodeModulesBundle and noExternal are used together

### DIFF
--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -242,6 +242,11 @@ export async function resolveUserConfig(
     const noExternalPatterns = toArray(noExternal)
     noExternal = (id) => matchPattern(id, noExternalPatterns)
   }
+  if (skipNodeModulesBundle && noExternal != null) {
+    throw new TypeError(
+      '`skipNodeModulesBundle` and `noExternal` are mutually exclusive options and cannot be used together.',
+    )
+  }
   if (inlineOnly != null && inlineOnly !== false) {
     inlineOnly = toArray(inlineOnly)
   }


### PR DESCRIPTION
## Summary

- Throw a `TypeError` when `skipNodeModulesBundle` and `noExternal` are both configured, as they are mutually exclusive options

## Context

`skipNodeModulesBundle` means "do not bundle any dependencies from node_modules", while `noExternal` means "force certain dependencies to be bundled". Using them together leads to ambiguous behavior where transitive dependencies of `noExternal` packages are still externalized by `skipNodeModulesBundle`.

Closes #741