### PR TITLE
docs: document `inlineOnly` option for dependency handling

### DIFF
--- a/docs/options/dependencies.md
+++ b/docs/options/dependencies.md
@@ -32,6 +32,30 @@ export default defineConfig({
 
 This will prevent `tsdown` from parsing and bundling any dependencies from `node_modules`, regardless of how they are referenced in your code.
 
+## Strict Inline Control with `inlineOnly`
+
+The `inlineOnly` option acts as a whitelist for dependencies that are allowed to be bundled from `node_modules`. If any dependency not in the list is found in the bundle, tsdown will throw an error. This is useful for preventing unexpected dependencies from being silently inlined into your output, especially in large projects.
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  inlineOnly: ['cac', 'bumpp'],
+})
+```
+
+In this example, only `cac` and `bumpp` are allowed to be bundled. If any other `node_modules` dependency is imported, tsdown will throw an error with a message indicating which dependency was unexpectedly bundled and which files imported it.
+
+### Behavior
+
+- **`inlineOnly` is an array** (e.g., `['cac', /^my-/]`): Only dependencies matching the list are allowed to be bundled. An error is thrown for any others. Unused patterns in the list will also be reported.
+- **`inlineOnly` is `false`**: All warnings and checks about bundled dependencies are suppressed.
+- **`inlineOnly` is not set** (default): A warning is shown if any `node_modules` dependencies are bundled, suggesting you add the `inlineOnly` option or set it to `false` to suppress warnings.
+
+::: tip
+Make sure to include all required sub-dependencies in the `inlineOnly` list as well, not just the top-level packages you directly import.
+:::
+
 ## Customizing Dependency Handling
 
 `tsdown` provides two options to override the default behavior:
@@ -90,6 +114,7 @@ export default defineConfig({
   - `dependencies` and `peerDependencies` are treated as external and not bundled.
   - `devDependencies` and phantom dependencies are only bundled if they are actually used in your code.
 - **Customization**:
+  - Use `inlineOnly` to whitelist dependencies allowed to be bundled, and throw an error for any others.
   - Use `external` to mark specific dependencies as external.
   - Use `noExternal` to force specific dependencies to be bundled.
   - Use `skipNodeModulesBundle` to skip resolving and bundling all dependencies from `node_modules`.

--- a/docs/zh-CN/options/dependencies.md
+++ b/docs/zh-CN/options/dependencies.md
@@ -32,6 +32,30 @@ export default defineConfig({
 
 这样，无论您的代码如何引用，`tsdown` 都不会解析或打包任何来自 `node_modules` 的依赖。
 
+## 使用 `inlineOnly` 严格控制内联依赖
+
+`inlineOnly` 选项作为允许从 `node_modules` 中打包的依赖白名单。如果有任何不在列表中的依赖被打包，tsdown 将抛出错误。这对于防止意外的依赖被静默内联到输出文件中非常有用，尤其是在大型项目中可能存在许多依赖的情况下。
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  inlineOnly: ['cac', 'bumpp'],
+})
+```
+
+在此示例中，只有 `cac` 和 `bumpp` 允许被打包。如果引入了任何其他 `node_modules` 依赖，tsdown 将抛出错误，指出哪个依赖被意外打包以及哪些文件引用了它。
+
+### 行为
+
+- **`inlineOnly` 为数组**（例如 `['cac', /^my-/]`）：只有匹配列表的依赖才允许被打包，其他依赖会触发错误。列表中未使用的模式也会被报告。
+- **`inlineOnly` 为 `false`**：抑制所有关于打包依赖的警告和检查。
+- **`inlineOnly` 未设置**（默认）：如果有 `node_modules` 依赖被打包，会显示一条警告，建议您添加 `inlineOnly` 选项或将其设置为 `false` 来抑制警告。
+
+::: tip
+请确保在 `inlineOnly` 列表中包含所有必需的子依赖，而不仅仅是您直接导入的顶层包。
+:::
+
 ## 自定义依赖处理
 
 `tsdown` 提供了两个选项来覆盖默认行为：
@@ -90,6 +114,7 @@ export default defineConfig({
   - `dependencies` 和 `peerDependencies` 被视为外部依赖，不会被打包。
   - `devDependencies` 和幻影依赖只有在代码中实际使用时才会被打包。
 - **自定义**：
+  - 使用 `inlineOnly` 设置允许被打包的依赖白名单，不在列表中的依赖会触发错误。
   - 使用 `external` 将特定依赖标记为外部依赖。
   - 使用 `noExternal` 强制将特定依赖打包。
   - 使用 `skipNodeModulesBundle` 跳过解析和打包所有来自 `node_modules` 的依赖。

--- a/skills/tsdown/SKILL.md
+++ b/skills/tsdown/SKILL.md
@@ -85,6 +85,7 @@ export default defineConfig({
 |---------|-------|-----------|
 | External deps | `external: ['react', /^@myorg\//]` | [option-dependencies](references/option-dependencies.md) |
 | Inline deps | `noExternal: ['dep-to-bundle']` | [option-dependencies](references/option-dependencies.md) |
+| Inline only | `inlineOnly: ['cac', 'bumpp']` - Whitelist bundled deps | [option-dependencies](references/option-dependencies.md) |
 | Auto external | Automatic peer/dependency externalization | [option-dependencies](references/option-dependencies.md) |
 
 ## Output Enhancement

--- a/skills/tsdown/references/option-dependencies.md
+++ b/skills/tsdown/references/option-dependencies.md
@@ -54,6 +54,28 @@ export default defineConfig({
 })
 ```
 
+### `inlineOnly`
+
+Whitelist of dependencies allowed to be bundled from node_modules. Throws an error if any unlisted dependency is bundled:
+
+```ts
+export default defineConfig({
+  entry: ['src/index.ts'],
+  inlineOnly: [
+    'cac',               // Allow bundling cac
+    'bumpp',             // Allow bundling bumpp
+    /^my-utils/,         // Regex patterns supported
+  ],
+})
+```
+
+**Behavior:**
+- **Array** (`['cac', /^my-/]`): Only matching dependencies can be bundled. Error for others.
+- **`false`**: Suppress all warnings about bundled dependencies.
+- **Not set** (default): Warns if any node_modules dependencies are bundled.
+
+**Note:** Include all sub-dependencies in the list, not just top-level imports.
+
 ### `skipNodeModulesBundle`
 
 Skip resolving and bundling ALL node_modules:


### PR DESCRIPTION
## Summary

- Add documentation for the `inlineOnly` option in English (`docs/options/dependencies.md`) and Chinese (`docs/zh-CN/options/dependencies.md`)
- Update skill references (`skills/tsdown/SKILL.md` and `skills/tsdown/references/option-dependencies.md`)

The `inlineOnly` option acts as a whitelist for dependencies allowed to be bundled from `node_modules`, throwing an error if any unlisted dependency is found in the bundle.