### PR TITLE
fix(css): not generating sourcemap

### DIFF
--- a/src/features/css/splitting.ts
+++ b/src/features/css/splitting.ts
@@ -27,7 +27,7 @@ export function CssCodeSplitPlugin(
         if (
           asset.type === 'asset' &&
           typeof asset.source === 'string' &&
-          RE_CSS.test(fileName)
+          RE_CSS.test(asset.fileName)
         ) {
           cssAssets.set(asset.fileName, asset.source)
         }


### PR DESCRIPTION
### Description

Basically applies the fix suggested at #753, I run locally and fixed the issue to emit the sourcemap for CSS files.

### Linked Issues

Fixes #753