### PR TITLE
fix(copy): downgrade "no files matched" from warn to info

### DIFF
--- a/src/features/copy.ts
+++ b/src/features/copy.ts
@@ -69,7 +69,7 @@ export async function copy(options: ResolvedConfig): Promise<void> {
   ).flat()
 
   if (!resolved.length) {
-    options.logger.info(options.nameLabel, `No files matched for copying.`)
+    options.logger.warn(options.nameLabel, `No files matched for copying.`)
     return
   }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/rolldown/tsdown/issues/774

When the `copy` option is configured with a glob pattern that matches zero files (e.g., `copy: [{ from: 'src/**/*.png', to: 'dist' }]`), the build fails in CI because `failOnWarn` defaults to `'ci-only'`, which promotes the warning to an error via `process.exitCode = 1`.

An empty glob match for copy is a benign, expected condition — not a build problem — so this downgrades the log level from `warn` to `info` to prevent it from failing the build.


