### PR TITLE
feat(css): support node_modules packages in Sass

### DIFF
--- a/packages/css/src/lightningcss.ts
+++ b/packages/css/src/lightningcss.ts
@@ -1,17 +1,10 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
-import { ResolverFactory } from 'rolldown/experimental'
 import { compilePreprocessor, getPreprocessorLang } from './preprocessors.ts'
+import { getCssResolver, resolveWithResolver } from './resolve.ts'
 import type { LightningCSSOptions, PreprocessorOptions } from './options.ts'
 import type { Targets } from 'lightningcss'
 import type { Logger } from 'tsdown/internal'
-
-let resolver: ResolverFactory | undefined
-function getResolver(): ResolverFactory {
-  return (resolver ??= new ResolverFactory({
-    conditionNames: ['style', 'default'],
-  }))
-}
 
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
@@ -100,15 +93,14 @@ export async function bundleWithLightningCSS(
         return fileCode
       },
       resolve(specifier: string, from: string) {
-        const dir = path.dirname(from)
-        const result = getResolver().sync(dir, specifier)
-        if (result.error || !result.path) {
+        const resolved = resolveWithResolver(getCssResolver(), specifier, from)
+        if (!resolved) {
           options.logger.warn(
-            `[@tsdown/css] Failed to resolve import '${specifier}' from '${from}': ${result.error || 'unknown error'}`,
+            `[@tsdown/css] Failed to resolve import '${specifier}' from '${from}'`,
           )
-          return path.resolve(dir, specifier)
+          return path.resolve(path.dirname(from), specifier)
         }
-        return result.path
+        return resolved
       },
     },
   })

--- a/packages/css/src/preprocessors.ts
+++ b/packages/css/src/preprocessors.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { getSassResolver, resolveWithResolver } from './resolve.ts'
 import type { PreprocessorOptions } from './options.ts'
 
 export type PreprocessorLang = 'sass' | 'scss' | 'less' | 'styl' | 'stylus'
@@ -251,8 +252,7 @@ async function compileSass(
         ? fileURLToPath(context.containingUrl)
         : filename
 
-      const dir = path.dirname(importer)
-      const resolved = await tryResolveScss(url, dir)
+      const resolved = await tryResolveScss(url, importer)
       if (resolved) {
         return pathToFileURL(resolved)
       }
@@ -291,8 +291,9 @@ async function compileSass(
 
 async function tryResolveScss(
   url: string,
-  dir: string,
+  importer: string,
 ): Promise<string | undefined> {
+  const dir = path.dirname(importer)
   const { existsSync } = await import('node:fs')
   const extensions = ['.scss', '.sass', '.css']
   const prefixes = ['', '_']
@@ -306,28 +307,28 @@ async function tryResolveScss(
       )
       if (existsSync(file)) return file
     }
-    return undefined
-  }
+  } else {
+    for (const ext of extensions) {
+      for (const prefix of prefixes) {
+        const file = path.resolve(
+          dir,
+          path.dirname(url),
+          prefix + path.basename(url) + ext,
+        )
+        if (existsSync(file)) return file
+      }
+    }
 
-  for (const ext of extensions) {
-    for (const prefix of prefixes) {
-      const file = path.resolve(
-        dir,
-        path.dirname(url),
-        prefix + path.basename(url) + ext,
-      )
-      if (existsSync(file)) return file
+    for (const ext of extensions) {
+      for (const prefix of prefixes) {
+        const file = path.resolve(dir, url, `${prefix}index${ext}`)
+        if (existsSync(file)) return file
+      }
     }
   }
 
-  for (const ext of extensions) {
-    for (const prefix of prefixes) {
-      const file = path.resolve(dir, url, `${prefix}index${ext}`)
-      if (existsSync(file)) return file
-    }
-  }
-
-  return undefined
+  // Fall back to node_modules resolution
+  return resolveWithResolver(getSassResolver(), url, importer)
 }
 
 let _sass: any

--- a/packages/css/src/resolve.ts
+++ b/packages/css/src/resolve.ts
@@ -1,0 +1,32 @@
+import path from 'node:path'
+import { ResolverFactory } from 'rolldown/experimental'
+
+let cssResolver: ResolverFactory | undefined
+let sassResolver: ResolverFactory | undefined
+
+export function getCssResolver(): ResolverFactory {
+  return (cssResolver ??= new ResolverFactory({
+    conditionNames: ['style', 'default'],
+  }))
+}
+
+export function getSassResolver(): ResolverFactory {
+  return (sassResolver ??= new ResolverFactory({
+    conditionNames: ['sass', 'style', 'default'],
+    mainFields: ['sass', 'style', 'main'],
+    extensions: ['.scss', '.sass', '.css'],
+  }))
+}
+
+export function resolveWithResolver(
+  resolver: ResolverFactory,
+  specifier: string,
+  from: string,
+): string | undefined {
+  const dir = path.dirname(from)
+  const result = resolver.sync(dir, specifier)
+  if (result.error || !result.path) {
+    return
+  }
+  return result.path
+}

--- a/tests/__snapshots__/css/sass-resolves-node_modules-packages.snap.md
+++ b/tests/__snapshots__/css/sass-resolves-node_modules-packages.snap.md
@@ -1,0 +1,15 @@
+## index.css
+
+```css
+body {
+  color: #ff0000;
+}
+
+```
+
+## index.mjs
+
+```mjs
+export {};
+
+```

--- a/tests/css.test.ts
+++ b/tests/css.test.ts
@@ -92,6 +92,26 @@ describe('css', () => {
     expect(outputFiles).toEqual(['index.css', 'index.mjs'])
   })
 
+  test('sass resolves node_modules packages', async (context) => {
+    const { outputFiles, snapshot } = await testBuild({
+      context,
+      files: {
+        'index.ts': `import './foo.scss'`,
+        'foo.scss': `@use '@my-lib/styles/vars';\nbody { color: vars.$primary; }`,
+        'node_modules/@my-lib/styles/vars.scss': `$primary: #ff0000;`,
+        'node_modules/@my-lib/styles/package.json': `{"name":"@my-lib/styles","main":"index.js"}`,
+      },
+      options: {
+        entry: ['index.ts'],
+        css: {
+          splitting: true,
+        },
+      },
+    })
+    expect(outputFiles).toEqual(['index.css', 'index.mjs'])
+    expect(snapshot).toContain('#ff0000')
+  })
+
   test('with sass and dts=true and splitting=true', async (context) => {
     const { outputFiles } = await testBuild({
       context,


### PR DESCRIPTION
## Summary

Extract shared ResolverFactory logic into `resolve.ts` module and add node_modules package resolution support for Sass `@use`/`@import` statements. The Sass resolver now falls back to oxc's module resolver (matching Vite's approach) when local file resolution fails, enabling packages like `@vuepress/helper` to be imported directly without manual `NodePackageImporter` configuration.

Fixes #811

## Test Coverage

Added test case `sass resolves node_modules packages` that verifies `@use '@my-lib/styles/vars'` correctly resolves scoped packages from node_modules using the oxc resolver with proper `sass` and `style` condition/mainFields support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)