### PR TITLE
Add test case for preserving folder structure in `unbundle` mode

### DIFF
--- a/tests/__snapshots__/unbundle/preserve-folder-structure.snap.md
+++ b/tests/__snapshots__/unbundle/preserve-folder-structure.snap.md
@@ -1,0 +1,9 @@
+## utils/bar.mjs
+
+```mjs
+//#region src/utils/bar.ts
+const bar = 2;
+//#endregion
+export { bar };
+
+```

--- a/tests/unbundle.test.ts
+++ b/tests/unbundle.test.ts
@@ -50,6 +50,7 @@ describe('unbundle', () => {
       files,
       options: {
         entry: ['src/**/*'],
+        root: 'src',
         unbundle: true,
       },
     })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.

-->

### Description

This PR as a reproduction example for a bug where the folder structure is not being preserved in `unbundle` mode.

### Linked Issues
#818 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
