### PR TITLE
docs(exe): fix output directory example

### DIFF
--- a/docs/options/exe.md
+++ b/docs/options/exe.md
@@ -114,7 +114,7 @@ export default defineConfig({
 This downloads the target platform's Node.js binary from nodejs.org, caches it locally, and uses it to build the executable. The output files are named with platform and architecture suffixes:
 
 ```
-dist/
+build/
   cli-linux-x64
   cli-darwin-arm64
   cli-win-x64.exe

--- a/docs/zh-CN/options/exe.md
+++ b/docs/zh-CN/options/exe.md
@@ -114,7 +114,7 @@ export default defineConfig({
 这会从 nodejs.org 下载目标平台的 Node.js 二进制文件，缓存到本地，并使用它来构建可执行文件。输出文件会带有平台和架构后缀：
 
 ```
-dist/
+build/
   cli-linux-x64
   cli-darwin-arm64
   cli-win-x64.exe


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.

-->

- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Since [v0.21.2](https://github.com/rolldown/tsdown/releases/tag/v0.21.2), the default output directory for exe has been changed to `build/`, but the documentation still showed `dist/` in the example output.