### PR TITLE
feat(dts): add `cjsReexport` option to eliminate dual module type hazard

### DIFF
--- a/dts.snapshot.json
+++ b/dts.snapshot.json
@@ -127,6 +127,7 @@
     "DepsConfig": "interface DepsConfig {\n neverBundle?: ExternalOption\n alwaysBundle?: Arrayable<string | RegExp> | NoExternalFn\n onlyBundle?: Arrayable<string | RegExp> | false\n onlyAllowBundle?: Arrayable<string | RegExp> | false\n skipNodeModulesBundle?: boolean\n}",
     "DepsPlugin": "declare function DepsPlugin(_: ResolvedConfig, _: TsdownBundle): Plugin",
     "DevtoolsOptions": "interface DevtoolsOptions extends NonNullable<InputOptions['devtools']> {\n ui?: boolean | Partial<StartOptions>\n clean?: boolean\n}",
+    "DtsOptions": "interface DtsOptions extends Options$1 {\n cjsReexport?: boolean\n}",
     "ExeOptions": "interface ExeOptions extends ExeExtensionOptions {\n seaConfig?: Omit<SeaConfig, 'main' | 'output' | 'mainFormat'>\n fileName?: string | ((_: RolldownChunk) => string)\n outDir?: string\n}",
     "ExportsOptions": "interface ExportsOptions {\n devExports?: boolean | string\n packageJson?: boolean\n all?: boolean\n exclude?: (RegExp | string)[]\n legacy?: boolean\n customExports?: Record<string, any> | ((_: Record<string, any>, _: { pkg: PackageJson; chunks: ChunksByFormat; isPublish: boolean }) => Awaitable<Record<string, any>>)\n inlinedDependencies?: boolean\n bin?: boolean | string | Record<string, string>\n}",
     "Format": "type Format = ModuleFormat",

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,3 +1,5 @@
+import { writeFile } from 'node:fs/promises'
+import path from 'node:path'
 import { bold, green } from 'ansis'
 import { clearRequireCache } from 'import-without-cache'
 import {
@@ -289,7 +291,7 @@ async function buildSingle(
     }
 
     const configs: BuildOptions[] = [buildOptions]
-    if (format === 'cjs' && dts) {
+    if (format === 'cjs' && dts && (!isDualFormat || !dts.cjsReexport)) {
       configs.push(
         await getBuildOptions(
           config,
@@ -308,6 +310,11 @@ async function buildSingle(
   async function postBuild() {
     await copy(config)
     await buildExe(config, chunks)
+
+    if (format === 'cjs' && dts && dts.cjsReexport && isDualFormat) {
+      await writeCjsDtsReexports(chunks, outDir, config.write !== false)
+    }
+
     if (!hasBuilt) {
       await done(bundle)
     }
@@ -317,5 +324,29 @@ async function buildSingle(
 
     ab?.abort()
     ab = executeOnSuccess(config)
+  }
+}
+
+async function writeCjsDtsReexports(
+  chunks: RolldownChunk[],
+  outDir: string,
+  write: boolean,
+): Promise<void> {
+  for (const chunk of chunks) {
+    if (chunk.type !== 'chunk') continue
+
+    // Match CJS JS output files: .cjs (fixed extension) or .js (non-fixed)
+    const match = chunk.fileName.match(/^(.*)\.(cjs|js)$/)
+    if (!match) continue
+
+    const baseName = match[1]
+    const dCtsName =
+      match[2] === 'cjs' ? `${baseName}.d.cts` : `${baseName}.d.ts`
+    const dMtsBasename = path.basename(`${baseName}.d.mts`)
+    const content = `export * from './${dMtsBasename}'\n`
+
+    if (write) {
+      await writeFile(path.join(outDir, dCtsName), content)
+    }
   }
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,5 +1,3 @@
-import { writeFile } from 'node:fs/promises'
-import path from 'node:path'
 import { bold, green } from 'ansis'
 import { clearRequireCache } from 'import-without-cache'
 import {
@@ -311,10 +309,6 @@ async function buildSingle(
     await copy(config)
     await buildExe(config, chunks)
 
-    if (format === 'cjs' && dts && dts.cjsReexport && isDualFormat) {
-      await writeCjsDtsReexports(chunks, outDir, config.write !== false)
-    }
-
     if (!hasBuilt) {
       await done(bundle)
     }
@@ -324,29 +318,5 @@ async function buildSingle(
 
     ab?.abort()
     ab = executeOnSuccess(config)
-  }
-}
-
-async function writeCjsDtsReexports(
-  chunks: RolldownChunk[],
-  outDir: string,
-  write: boolean,
-): Promise<void> {
-  for (const chunk of chunks) {
-    if (chunk.type !== 'chunk') continue
-
-    // Match CJS JS output files: .cjs (fixed extension) or .js (non-fixed)
-    const match = chunk.fileName.match(/^(.*)\.(cjs|js)$/)
-    if (!match) continue
-
-    const baseName = match[1]
-    const dCtsName =
-      match[2] === 'cjs' ? `${baseName}.d.cts` : `${baseName}.d.ts`
-    const dMtsBasename = path.basename(`${baseName}.d.mts`)
-    const content = `export * from './${dMtsBasename}'\n`
-
-    if (write) {
-      await writeFile(path.join(outDir, dCtsName), content)
-    }
   }
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -296,7 +296,7 @@ async function buildSingle(
           format,
           configFiles,
           bundle,
-          true,
+          true, // cjsDts
           isDualFormat,
         ),
       )

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -44,8 +44,26 @@ import type {
   OutputOptions,
   TreeshakingOptions,
 } from 'rolldown'
-import type { Options as DtsOptions } from 'rolldown-plugin-dts'
+import type { Options as RolldownPluginDtsOptions } from 'rolldown-plugin-dts'
 import type { Options as UnusedOptions } from 'unplugin-unused'
+
+export interface DtsOptions extends RolldownPluginDtsOptions {
+  /**
+   * When building dual ESM+CJS formats, generate a `.d.cts` re-export stub
+   * instead of running a full second TypeScript compilation pass.
+   *
+   * The stub re-exports everything from the corresponding `.d.mts` file,
+   * ensuring CJS and ESM consumers share the same type declarations. This
+   * eliminates the TypeScript "dual module hazard" where separate `.d.cts`
+   * and `.d.mts` declarations cause `TS2352` ("neither type sufficiently
+   * overlaps") errors when casting between types derived from the same class.
+   *
+   * Only applies when building both `esm` and `cjs` formats simultaneously.
+   *
+   * @default false
+   */
+  cjsReexport?: boolean
+}
 
 export type Sourcemap = boolean | 'inline' | 'hidden'
 export type Format = ModuleFormat
@@ -83,7 +101,6 @@ export type {
   CopyOptionsFn,
   DepsConfig,
   DevtoolsOptions,
-  DtsOptions,
   ExeOptions,
   ExportsOptions,
   NoExternalFn,

--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -11,6 +11,7 @@ import {
   type Plugin,
   type RolldownPluginOption,
 } from 'rolldown'
+import { filename_js_to_dts, RE_JS } from 'rolldown-plugin-dts/internal'
 import { importGlobPlugin } from 'rolldown/experimental'
 import pkg from '../../package.json' with { type: 'json' }
 import { mergeUserOptions } from '../config/options.ts'
@@ -349,16 +350,19 @@ export function CjsDtsReexportPlugin(): Plugin {
       for (const chunk of Object.values(bundle)) {
         if (chunk.type !== 'chunk') continue
 
-        const match = chunk.fileName.match(/^(.*)\.(cjs|js)$/)
-        if (!match) continue
+        if (!chunk.fileName.endsWith('.cjs') && !chunk.fileName.endsWith('.js'))
+          continue
 
-        const baseName = match[1]
-        const dCtsName =
-          match[2] === 'cjs' ? `${baseName}.d.cts` : `${baseName}.d.ts`
-        const dMtsBasename = path.basename(`${baseName}.d.mts`)
+        const dMtsBasename = path.basename(
+          chunk.fileName.replace(RE_JS, '.d.mts'),
+        )
         const content = `export * from './${dMtsBasename}'\n`
 
-        this.emitFile({ type: 'asset', fileName: dCtsName, source: content })
+        this.emitFile({
+          type: 'prebuilt-chunk',
+          fileName: filename_js_to_dts(chunk.fileName),
+          code: content,
+        })
       }
     },
   }

--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -117,9 +117,10 @@ async function resolveInputOptions(
 
   if (dts) {
     const { dts: dtsPlugin } = await import('rolldown-plugin-dts')
+    const { cjsReexport: _, ...dtsPluginOptions } = dts
     const options: DtsOptions = {
       tsconfig,
-      ...dts,
+      ...dtsPluginOptions,
     }
 
     if (format === 'es') {

--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -133,6 +133,8 @@ async function resolveInputOptions(
           cjsDefault,
         }),
       )
+    } else if (dts.cjsReexport && isDualFormat) {
+      plugins.push(CjsDtsReexportPlugin())
     }
   }
   let cssPostPlugins: Plugin[] | undefined
@@ -337,6 +339,28 @@ function handlePluginInspect(plugins: RolldownPluginOption) {
         return `"rolldown plugin: ${plugins.name}"`
       }
     }
+  }
+}
+
+export function CjsDtsReexportPlugin(): Plugin {
+  return {
+    name: 'tsdown:cjs-dts-reexport',
+    generateBundle(_options, bundle) {
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== 'chunk') continue
+
+        const match = chunk.fileName.match(/^(.*)\.(cjs|js)$/)
+        if (!match) continue
+
+        const baseName = match[1]
+        const dCtsName =
+          match[2] === 'cjs' ? `${baseName}.d.cts` : `${baseName}.d.ts`
+        const dMtsBasename = path.basename(`${baseName}.d.mts`)
+        const content = `export * from './${dMtsBasename}'\n`
+
+        this.emitFile({ type: 'asset', fileName: dCtsName, source: content })
+      }
+    },
   }
 }
 

--- a/tests/__snapshots__/cjs-dts-reexport.snap.md
+++ b/tests/__snapshots__/cjs-dts-reexport.snap.md
@@ -1,4 +1,4 @@
-## index.cjs
+## folder/index.cjs
 
 ```cjs
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
@@ -11,14 +11,14 @@ exports.hello = hello;
 
 ```
 
-## index.d.cts
+## folder/index.d.cts
 
 ```cts
 export * from './index.d.mts'
 
 ```
 
-## index.d.mts
+## folder/index.d.mts
 
 ```mts
 //#region index.d.ts
@@ -27,7 +27,7 @@ declare function hello(): void;
 export { hello };
 ```
 
-## index.mjs
+## folder/index.mjs
 
 ```mjs
 //#region index.ts

--- a/tests/__snapshots__/cjs-dts-reexport.snap.md
+++ b/tests/__snapshots__/cjs-dts-reexport.snap.md
@@ -1,0 +1,40 @@
+## index.cjs
+
+```cjs
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region index.ts
+function hello() {
+	console.log("Hello!");
+}
+//#endregion
+exports.hello = hello;
+
+```
+
+## index.d.cts
+
+```cts
+export * from './index.d.mts'
+
+```
+
+## index.d.mts
+
+```mts
+//#region index.d.ts
+declare function hello(): void;
+//#endregion
+export { hello };
+```
+
+## index.mjs
+
+```mjs
+//#region index.ts
+function hello() {
+	console.log("Hello!");
+}
+//#endregion
+export { hello };
+
+```

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -98,6 +98,22 @@ test('cjs default', async (context) => {
   })
 })
 
+test('cjs dts reexport', async (context) => {
+  const files = {
+    'index.ts': `export function hello(): void {
+      console.log('Hello!')
+    }`,
+  }
+  await testBuild({
+    context,
+    files,
+    options: {
+      format: ['esm', 'cjs'],
+      dts: { cjsReexport: true },
+    },
+  })
+})
+
 test('fixed extension', async (context) => {
   const files = {
     'index.ts': `export default 10`,

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -108,6 +108,9 @@ test('cjs dts reexport', async (context) => {
     context,
     files,
     options: {
+      entry: {
+        'folder/index': 'index.ts',
+      },
       format: ['esm', 'cjs'],
       dts: { cjsReexport: true },
     },


### PR DESCRIPTION
# Description

When building dual ESM+CJS formats, tsdown runs two separate TypeScript compilation passes, one producing `.d.mts`, one producing an independent `.d.cts`. Because TypeScript's class identity is nominal, these two declarations are treated as unrelated types by consumers that mix CJS and ESM resolution paths (e.g. NestJS apps importing a package that also has ESM-only internal dependencies). This produces `TS2352` "neither type sufficiently overlaps" when casting between types derived from the same class.

This PR adds a `dts.cjsReexport: boolean` option (opt-in, default `false`). When enabled in a dual-format build, tsdown skips the second compilation pass and instead emits a `.d.cts` stub via a Rolldown plugin (`generateBundle` hook) that re-exports from the corresponding `.d.mts`:

```js
// dist/index.d.cts (generated)
export * from './index.d.mts'
```

Both CJS and ESM consumers now resolve to the same declaration, eliminating the dual module type hazard entirely.

> Note: `export *` does not re-export default. Packages with a default export and named exports should be aware of this — for named-export-only packages this is a non-issue.

## Implementation

The stub is emitted by `CjsDtsReexportPlugin` (in `src/features/rolldown.ts`), which uses Rolldown's `generateBundle` hook to call `this.emitFile`. This integrates naturally with the build pipeline and respects the `write` option without any direct filesystem access.

## Additional info

This PR contains AI-assisted code, but I have carefully reviewed it myself. We use `tsdown` on https://github.com/supabase/supabase-js and it would be nice if we could use this.