### PR TITLE
fix(css): don't override internal importer

### DIFF
--- a/packages/css/src/preprocessors.ts
+++ b/packages/css/src/preprocessors.ts
@@ -292,8 +292,8 @@ async function compileSass(
     url: pathToFileURL(filename),
     sourceMap: false,
     syntax: lang === 'sass' ? 'indented' : 'scss',
-    importers: [internalImporter, ...(sassOptions.importers ?? [])],
     ...sassOptions,
+    importers: [internalImporter, ...(sassOptions.importers ?? [])],
   })
 
   return {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.

-->

- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

This PR fixes the fact, that user specified importers for sass via `preprocessorOptions` override the default importer from tsdown.
This breaks e.g. importing from `node_modules`.

For details and reproduction link, see the corresponding issue: #859

### Linked Issues

Fixes: #859

### Additional context

I fixed the issue by doing the minimal changes, keeping user values overriding all values _expect_ for the special case handling of the `importers` array.

If user values overriding the other values would also be considered unintended behaviour, the object spread for the user values could be moved up even further:
```ts
  const result = await sass.compileStringAsync(data, {
    ...sassOptions,
    url: pathToFileURL(filename),
    sourceMap: false,
    syntax: lang === 'sass' ? 'indented' : 'scss',
    importers: [internalImporter, ...(sassOptions.importers ?? [])],
  })
```

if you wanna change it to that, let me know (or feel free to edit yourself, if you prefer).
