### PR TITLE
chore: remove the @publint/pack dependency that is no longer used

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
   },
   "devDependencies": {
     "@arethetypeswrong/core": "catalog:peer",
-    "@publint/pack": "catalog:dev",
     "@sxzz/eslint-config": "catalog:dev",
     "@sxzz/prettier-config": "catalog:dev",
     "@sxzz/test-utils": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,6 @@ catalogs:
       specifier: ^3.1.2
       version: 3.1.2
   dev:
-    '@publint/pack':
-      specifier: ^0.1.4
-      version: 0.1.4
     '@sxzz/eslint-config':
       specifier: ^7.8.3
       version: 7.8.3
@@ -280,9 +277,6 @@ importers:
       '@arethetypeswrong/core':
         specifier: catalog:peer
         version: 0.18.2
-      '@publint/pack':
-        specifier: catalog:dev
-        version: 0.1.4
       '@sxzz/eslint-config':
         specifier: catalog:dev
         version: 7.8.3(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/parser@8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/rule-tester@8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/typescript-estree@8.57.2(typescript@6.0.2))(@typescript-eslint/utils@8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2))(@unocss/eslint-plugin@66.6.7(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.1.0(jiti@2.6.1))(prettier@3.8.1)(typescript@6.0.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,6 @@ catalogs:
     '@clack/prompts': ^1.1.0
     giget: ^3.1.2
   dev:
-    '@publint/pack': ^0.1.4
     '@sxzz/eslint-config': ^7.8.3
     '@sxzz/prettier-config': ^2.3.1
     '@sxzz/test-utils': ^0.5.15

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,6 @@ export default defineConfig([
     name: 'tsdown',
     deps: {
       onlyBundle: [
-        '@publint/pack',
         'is-in-ci',
         'package-manager-detector',
         'pkg-types', // type-only


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.

-->

- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

https://github.com/rolldown/tsdown/commit/4a29176f564136483a381399ad54ea85dc3d4e9a

After that, shouldn't @publint/pack no longer exist?

<!-- e.g. is there anything you'd like reviewers to focus on? -->
