### PR TITLE
fix(css): strip `.module` from CSS output filenames

### DIFF
--- a/packages/css/src/plugin.ts
+++ b/packages/css/src/plugin.ts
@@ -23,6 +23,7 @@ import {
   RE_CSS,
   RE_CSS_INLINE,
   RE_INLINE,
+  toCssFileName,
 } from './utils.ts'
 import type { CSSModulesConfig } from 'lightningcss'
 import type { Plugin } from 'rolldown'
@@ -231,7 +232,7 @@ export function CssPlugin(
                 /[.*+?^${}()|[\]\\]/g,
                 String.raw`\$&`,
               )
-              const cssBasename = basename.replace(/\.[cm]?js$/, '.css')
+              const cssBasename = toCssFileName(basename)
               const importRE = new RegExp(
                 String.raw`(\bimport\s*["'][^"']*)${escaped}(["'];)`,
               )
@@ -239,7 +240,7 @@ export function CssPlugin(
             }
             // Direct CSS modules in this chunk need a prepended import
             if (chunk.moduleIds.some((id) => styles.has(id))) {
-              const cssFile = chunk.fileName.replace(/\.[cm]?js$/, '.css')
+              const cssFile = toCssFileName(chunk.fileName)
               const relativePath = path.posix.relative(
                 path.posix.dirname(chunk.fileName),
                 cssFile,

--- a/packages/css/src/post.ts
+++ b/packages/css/src/post.ts
@@ -1,6 +1,7 @@
 import { transformWithLightningCSS } from './lightningcss.ts'
 import { defaultCssBundleName, type ResolvedCssOptions } from './options.ts'
 import { removePureCssChunks } from './pure-chunk.ts'
+import { toCssFileName } from './utils.ts'
 import type { Plugin } from 'rolldown'
 
 export type CssStyles = Map<string, string>
@@ -71,7 +72,7 @@ export function CssPostPlugin(
 
           chunkCSS = await finalizeCss(chunkCSS)
 
-          const cssAssetFileName = chunk.fileName.replace(/\.[cm]?js$/, '.css')
+          const cssAssetFileName = toCssFileName(chunk.fileName)
           this.emitFile({
             type: 'asset',
             fileName: cssAssetFileName,

--- a/packages/css/src/utils.ts
+++ b/packages/css/src/utils.ts
@@ -7,6 +7,10 @@ export const RE_CSS_INLINE: RegExp =
 export const CSS_MODULE_RE: RegExp =
   /\.module\.(?:css|less|sass|scss|styl|stylus)(?:$|\?)/
 
+export function toCssFileName(jsFileName: string): string {
+  return jsFileName.replace(/(?:\.module)?(\.[cm]?js)$/, '.css')
+}
+
 export function getCleanId(id: string): string {
   const queryIndex = id.indexOf('?')
   return queryIndex === -1 ? id : id.slice(0, queryIndex)


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

When tsdown processes CSS module files (e.g., `Component.module.css`), the output CSS retained the `.module` suffix. Downstream bundlers would then re-process it as a CSS module, causing styles to be lost. This adds a `toCssFileName()` utility that strips `.module` when converting JS chunk filenames to CSS filenames, applied at all 3 sites where this conversion happens.

### Linked Issues

Fixes #864

### Additional context

The fix uses a single regex `(?:\.module)?(\.[cm]?js)$` → `.css` which handles both module and non-module filenames. All existing tests pass unchanged since they use JS entries that import `.module.css` files (so CSS filenames derive from the JS chunk name, not the CSS module filename).