### PR TITLE
feat(dts)!: auto-enable dts when tsconfig declaration is true

### DIFF
--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -5,6 +5,7 @@ import { blue } from 'ansis'
 import { createDefu } from 'defu'
 import isInCi from 'is-in-ci'
 import { createDebug } from 'obug'
+import { parseTsconfig } from 'rolldown-plugin-dts/internal'
 import { resolveClean } from '../features/clean.ts'
 import { resolveDepsConfig } from '../features/deps.ts'
 import { resolveEntry } from '../features/entry.ts'
@@ -156,7 +157,16 @@ export async function resolveUserConfig(
   exe = resolveFeatureOption(exe, {})
 
   if (dts == null) {
-    dts = exe ? false : !!(pkg?.types || pkg?.typings || hasExportsTypes(pkg))
+    if (exe) {
+      dts = false
+    } else if (pkg?.types || pkg?.typings || hasExportsTypes(pkg)) {
+      dts = true
+    } else if (tsconfig) {
+      const parsed = parseTsconfig(tsconfig)
+      dts = !!parsed.compilerOptions?.declaration
+    } else {
+      dts = false
+    }
   }
   dts = resolveFeatureOption(dts, {})
 


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

Auto-enable `dts` generation when `compilerOptions.declaration` is `true` in tsconfig. Previously, dts was only auto-enabled based on `package.json` fields (`types`, `typings`, or exports with types). Now tsdown also parses the tsconfig via `parseTsconfig` from `rolldown-plugin-dts/internal` as a fallback signal when those package.json fields are absent.

### Linked Issues

### Additional context