### PR TITLE
feat(attw): improve `ignoreRules` type to autocomplete known values

### DIFF
--- a/dts.snapshot.json
+++ b/dts.snapshot.json
@@ -114,7 +114,7 @@
     "#exports": []
   },
   "types-!~{00b}~.d.mts": {
-    "AttwOptions": "interface AttwOptions extends CheckPackageOptions {\n module?: typeof _$_arethetypeswrong_core0\n profile?: 'strict' | 'node16' | 'esm-only'\n level?: 'error' | 'warn'\n ignoreRules?: string[]\n}",
+    "AttwOptions": "interface AttwOptions extends CheckPackageOptions {\n module?: typeof _$_arethetypeswrong_core0\n profile?: 'strict' | 'node16' | 'esm-only'\n level?: 'error' | 'warn'\n ignoreRules?: ('no-resolution' | 'untyped-resolution' | 'false-cjs' | 'false-esm' | 'cjs-resolves-to-esm' | 'fallback-condition' | 'cjs-only-exports-default' | 'named-exports' | 'false-export-default' | 'missing-export-equals' | 'unexpected-module-syntax' | 'internal-resolution-error' | (string & {}))[]\n}",
     "BuildContext": "interface BuildContext {\n options: ResolvedConfig\n hooks: Hookable<TsdownHooks>\n}",
     "ChunkAddon": "type ChunkAddon = ChunkAddonObject | ChunkAddonFunction | string",
     "ChunkAddonFunction": "type ChunkAddonFunction = (_: { format: Format; fileName: string }) => ChunkAddonObject | string | undefined",

--- a/src/features/pkg/attw.ts
+++ b/src/features/pkg/attw.ts
@@ -76,7 +76,21 @@ export interface AttwOptions extends CheckPackageOptions {
    * ignoreRules: ['no-resolution', 'false-cjs']
    * ```
    */
-  ignoreRules?: string[]
+  ignoreRules?: (
+    | 'no-resolution'
+    | 'untyped-resolution'
+    | 'false-cjs'
+    | 'false-esm'
+    | 'cjs-resolves-to-esm'
+    | 'fallback-condition'
+    | 'cjs-only-exports-default'
+    | 'named-exports'
+    | 'false-export-default'
+    | 'missing-export-equals'
+    | 'unexpected-module-syntax'
+    | 'internal-resolution-error'
+    | (string & {})
+  )[]
 }
 
 /**


### PR DESCRIPTION
- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Closes https://github.com/rolldown/tsdown/issues/891

### Additional context

I left the type permissive so it allows any string as it did before, this merely improves the autocompletion. Typos will still pass as valid options, let me know if I should make the type strict by removing the `string & {}` part.
