### PR TITLE
feat: support adding .js extensions to subpath exports

### DIFF
--- a/dts.snapshot.json
+++ b/dts.snapshot.json
@@ -143,7 +143,7 @@
     "DevtoolsOptions": "interface DevtoolsOptions extends NonNullable<InputOptions['devtools']> {\n ui?: boolean | Partial<StartOptions>\n clean?: boolean\n}",
     "DtsOptions": "interface DtsOptions extends Options$1 {\n cjsReexport?: boolean\n}",
     "ExeOptions": "interface ExeOptions extends ExeExtensionOptions {\n seaConfig?: Omit<SeaConfig, 'main' | 'output' | 'mainFormat'>\n fileName?: string | ((_: RolldownChunk) => string)\n outDir?: string\n}",
-    "ExportsOptions": "interface ExportsOptions {\n devExports?: boolean | string\n packageJson?: boolean\n all?: boolean\n exclude?: (RegExp | string)[]\n legacy?: boolean\n customExports?: Record<string, any> | ((_: Record<string, any>, _: { pkg: PackageJson; chunks: ChunksByFormat; isPublish: boolean }) => Awaitable<Record<string, any>>)\n inlinedDependencies?: boolean\n bin?: boolean | string | Record<string, string>\n}",
+    "ExportsOptions": "interface ExportsOptions {\n devExports?: boolean | string\n packageJson?: boolean\n all?: boolean\n exclude?: (RegExp | string)[]\n legacy?: boolean\n customExports?: Record<string, any> | ((_: Record<string, any>, _: { pkg: PackageJson; chunks: ChunksByFormat; isPublish: boolean }) => Awaitable<Record<string, any>>)\n inlinedDependencies?: boolean\n bin?: boolean | string | Record<string, string>\n subpathExtension?: boolean\n}",
     "Format": "type Format = ModuleFormat",
     "InlineConfig": "interface InlineConfig extends UserConfig {\n config?: boolean | string\n configLoader?: 'auto' | 'native' | 'unrun'\n filter?: RegExp | Arrayable<string>\n}",
     "NoExternalFn": "type NoExternalFn = (_: string, _: string | undefined) => boolean | null | undefined | void",

--- a/src/features/pkg/exports.test.ts
+++ b/src/features/pkg/exports.test.ts
@@ -899,6 +899,30 @@ describe('generateExports', () => {
       }
     `)
   })
+
+  test('subpathExtension', async ({ expect }) => {
+    const results = generateExports(
+      { es: [genChunk('index.js'), genChunk('foo.js')] },
+      {
+        exports: { subpathExtension: true },
+      },
+    )
+    await expect(results).resolves.toMatchInlineSnapshot(`
+      {
+        "bin": undefined,
+        "exports": {
+          ".": "./index.js",
+          "./foo.js": "./foo.js",
+          "./package.json": "./package.json",
+        },
+        "inlinedDependencies": undefined,
+        "main": undefined,
+        "module": undefined,
+        "publishExports": undefined,
+        "types": undefined,
+      }
+    `)
+  })
 })
 
 function genChunk(

--- a/src/features/pkg/exports.ts
+++ b/src/features/pkg/exports.ts
@@ -112,6 +112,12 @@ export interface ExportsOptions {
    * bin: { tool: './src/cli-tool.ts' }
    */
   bin?: boolean | string | Record<string, string>
+
+  /**
+   * Add .js extension to all subpath exports.
+   * @default false
+   */
+  subpathExtension?: boolean
 }
 
 export async function writeExports(
@@ -187,6 +193,7 @@ export async function generateExports(
       legacy,
       inlinedDependencies: emitInlinedDeps = true,
       bin,
+      subpathExtension,
     },
     css,
     logger,
@@ -291,10 +298,13 @@ export async function generateExports(
   )
 
   let exports: Record<string, any> = Object.fromEntries(
-    sortedExportsMap.map(([name, subExport]) => [
-      name,
-      genSubExport(devExports, subExport),
-    ]),
+    sortedExportsMap.map(([name, subExport]) => {
+      let finalName = name
+      if (subpathExtension && name !== '.' && !/\.[^/]+$/.test(name)) {
+        finalName = `${name}.js`
+      }
+      return [finalName, genSubExport(devExports, subExport)]
+    }),
   )
   exportMeta(exports, all, packageJson)
   exportCss(exports, chunks, css, pkgRoot)
@@ -311,10 +321,13 @@ export async function generateExports(
   let publishExports: Record<string, any> | undefined
   if (devExports) {
     publishExports = Object.fromEntries(
-      sortedExportsMap.map(([name, subExport]) => [
-        name,
-        genSubExport(false, subExport),
-      ]),
+      sortedExportsMap.map(([name, subExport]) => {
+        let finalName = name
+        if (subpathExtension && name !== '.' && !/\.[^/]+$/.test(name)) {
+          finalName = `${name}.js`
+        }
+        return [finalName, genSubExport(false, subExport)]
+      }),
     )
     exportMeta(publishExports, all, packageJson)
     exportCss(publishExports, chunks, css, pkgRoot)


### PR DESCRIPTION
Support adding .js extensions to all exports (except root).

Added  option to  config.

Closes #898