### PR TITLE
fix: exclude shim file from bundled dependency hint

### DIFF
--- a/src/features/deps.ts
+++ b/src/features/deps.ts
@@ -218,6 +218,7 @@ export function DepsPlugin(
           if (chunk.type === 'asset') continue
 
           for (const id of chunk.moduleIds) {
+            if (id === shimFile) continue
             const parsed = await readBundledDepInfo(id)
             if (!parsed) continue
 


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

When `shims: true` is enabled, tsdown injects ESM shims (`__filename`, `__dirname`) by importing from its own `esm-shims.js`. Since this file resides in `node_modules/tsdown/`, the dependency detection in `generateBundle` incorrectly flags `tsdown` as a bundled dependency and shows a confusing hint. This PR skips the `shimFile` when iterating module IDs so the shim import is not reported.

### Linked Issues

Closes #907

### Additional context

The `shimFile` was already excluded in `externalStrategy()` during the `resolveId` phase, but the `generateBundle` hook runs independently and was missing the same filter.