### PR TITLE
feat(exports): enhance bin handling with devExports

### DIFF
--- a/src/features/pkg/exports.test.ts
+++ b/src/features/pkg/exports.test.ts
@@ -43,6 +43,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -66,6 +67,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -87,6 +89,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -108,6 +111,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -129,6 +133,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -153,6 +158,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": "./foo.cjs",
         "module": "./foo.js",
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -177,6 +183,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": "./foo.cjs",
         "module": "./foo.js",
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": "./foo.d.cts",
       }
@@ -201,6 +208,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": "./index.cjs",
         "module": "./index.mjs",
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": "./index.d.cts",
       }
@@ -255,6 +263,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": "./index.cjs",
         "module": "./index.js",
+        "publishBin": undefined,
         "publishExports": {
           ".": {
             "import": "./index.js",
@@ -351,6 +360,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -378,6 +388,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -401,6 +412,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -427,6 +439,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": "./index.cjs",
         "module": "./index.js",
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -453,6 +466,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -481,6 +495,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -509,6 +524,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -538,6 +554,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -586,6 +603,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": "./index.cjs",
         "module": "./index.js",
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": "./index.d.cts",
       }
@@ -611,6 +629,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -637,6 +656,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -662,6 +682,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -687,6 +708,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -953,7 +975,7 @@ describe('generateExports', () => {
     expect(results).toMatchObject({
       bin: { 'fake-pkg': './cli.js' },
     })
-    expect(results).not.toHaveProperty('publishBin')
+    expect(results.publishBin).toBeUndefined()
   })
 
   test('bin: scoped package name', async ({ expect }) => {
@@ -993,6 +1015,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -1019,6 +1042,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -1052,6 +1076,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": "./index.cjs",
         "module": "./index.js",
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -1077,6 +1102,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": undefined,
         "types": undefined,
       }
@@ -1150,6 +1176,7 @@ describe('generateExports', () => {
         "inlinedDependencies": undefined,
         "main": undefined,
         "module": undefined,
+        "publishBin": undefined,
         "publishExports": {
           ".": "./index.js",
           "./package.json": "./package.json",

--- a/src/features/pkg/exports.test.ts
+++ b/src/features/pkg/exports.test.ts
@@ -836,18 +836,124 @@ describe('generateExports', () => {
       {
         exports: {
           bin: {
-            mycli: './src/cli.ts',
-            mytool: './src/tool.ts',
+            'my-cli': './src/cli.ts',
+            'my-tool': './src/tool.ts',
           },
         },
       },
     )
     await expect(results).resolves.toMatchObject({
       bin: {
-        mycli: './cli.js',
-        mytool: './tool.js',
+        'my-cli': './cli.js',
+        'my-tool': './tool.js',
       },
     })
+  })
+
+  test('bin: true with devExports true adds publish bin', async ({
+    expect,
+  }) => {
+    const results = await generateExports(
+      {
+        es: [
+          genChunk(
+            'cli.js',
+            true,
+            path.resolve('./src/cli.ts'),
+            '#!/usr/bin/env node\n',
+          ),
+        ],
+      },
+      { exports: { devExports: true, bin: true } },
+    )
+    expect(results).toMatchObject({
+      bin: { 'fake-pkg': './src/cli.ts' },
+      publishBin: { 'fake-pkg': './cli.js' },
+    })
+  })
+
+  test('bin: string form with devExports true adds publish bin', async ({
+    expect,
+  }) => {
+    const results = await generateExports(
+      {
+        es: [
+          genChunk(
+            'cli.js',
+            true,
+            path.resolve('./src/cli.ts'),
+            '#!/usr/bin/env node\n',
+          ),
+        ],
+      },
+      { exports: { devExports: true, bin: './src/cli.ts' } },
+    )
+    expect(results).toMatchObject({
+      bin: { 'fake-pkg': './src/cli.ts' },
+      publishBin: { 'fake-pkg': './cli.js' },
+    })
+  })
+
+  test('bin: object form with devExports true adds publish bin', async ({
+    expect,
+  }) => {
+    const results = await generateExports(
+      {
+        es: [
+          genChunk(
+            'cli.js',
+            true,
+            path.resolve('./src/cli.ts'),
+            '#!/usr/bin/env node\n',
+          ),
+          genChunk(
+            'tool.js',
+            true,
+            path.resolve('./src/tool.ts'),
+            '#!/usr/bin/env node\n',
+          ),
+        ],
+      },
+      {
+        exports: {
+          devExports: true,
+          bin: {
+            'my-cli': './src/cli.ts',
+            'my-tool': './src/tool.ts',
+          },
+        },
+      },
+    )
+    expect(results).toMatchObject({
+      bin: {
+        'my-cli': './src/cli.ts',
+        'my-tool': './src/tool.ts',
+      },
+      publishBin: {
+        'my-cli': './cli.js',
+        'my-tool': './tool.js',
+      },
+    })
+  })
+
+  test('bin with conditional devExports keeps dist bin', async ({ expect }) => {
+    const results = await generateExports(
+      {
+        es: [
+          genChunk(
+            'cli.js',
+            true,
+            path.resolve('./src/cli.ts'),
+            '#!/usr/bin/env node\n',
+          ),
+        ],
+      },
+      { exports: { devExports: 'dev', bin: './src/cli.ts' } },
+    )
+    expect(results).toMatchObject({
+      bin: { 'fake-pkg': './cli.js' },
+    })
+    expect(results).not.toHaveProperty('publishBin')
   })
 
   test('bin: scoped package name', async ({ expect }) => {

--- a/src/features/pkg/exports.ts
+++ b/src/features/pkg/exports.ts
@@ -135,12 +135,8 @@ export async function writeExports(
   typeAssert(options.pkg)
 
   const { pkg } = options
-  const { publishExports, bin, ...generated } = await generateExports(
-    pkg,
-    chunks,
-    options,
-    inlinedDeps,
-  )
+  const { publishExports, publishBin, bin, ...generated } =
+    await generateExports(pkg, chunks, options, inlinedDeps)
 
   const updatedPkg = {
     ...pkg,
@@ -149,9 +145,10 @@ export async function writeExports(
     packageJsonPath: undefined,
   }
 
-  if (publishExports) {
+  if (publishExports || publishBin) {
     updatedPkg.publishConfig ||= {}
-    updatedPkg.publishConfig.exports = publishExports
+    if (publishExports) updatedPkg.publishConfig.exports = publishExports
+    if (publishBin) updatedPkg.publishConfig.bin = publishBin
   }
 
   const original = readFileSync(pkg.packageJsonPath, 'utf8')
@@ -188,6 +185,7 @@ export async function generateExports(
   bin?: string | Record<string, string>
   inlinedDependencies?: Record<string, string | string[]>
   publishExports?: Record<string, any>
+  publishBin?: string | Record<string, string>
 }> {
   typeAssert(options.exports)
   let {
@@ -295,7 +293,7 @@ export async function generateExports(
       if (!isDts) {
         subExport[format] = distFile
         if (chunk.facadeModuleId && !subExport.src) {
-          subExport.src = `./${slash(path.relative(pkgRoot, chunk.facadeModuleId))}`
+          subExport.src = relativePackagePath(pkgRoot, chunk.facadeModuleId)
         }
       }
     }
@@ -347,12 +345,25 @@ export async function generateExports(
     }
   }
 
+  const generatedBin = generateBin(
+    bin,
+    pkg,
+    chunks,
+    pkgRoot,
+    logger,
+    cwd,
+    devExports,
+  )
+
   return {
     main: legacy ? main || module || pkg.main : undefined,
     module: legacy ? module || pkg.module : undefined,
     types: legacy ? cjsTypes || esmTypes || pkg.types : pkg.types,
     exports,
-    bin: generateBin(bin, pkg, chunks, pkgRoot, logger, cwd),
+    bin: generatedBin.bin,
+    ...(generatedBin.publishBin === undefined
+      ? {}
+      : { publishBin: generatedBin.publishBin }),
     inlinedDependencies: emitInlinedDeps ? inlinedDeps : undefined,
     publishExports,
   }
@@ -445,6 +456,11 @@ export function hasExportsTypes(pkg?: PackageJson): boolean {
 
 const RE_SHEBANG = /^#!.*/
 
+type GeneratedBin = {
+  bin?: string | Record<string, string>
+  publishBin?: string | Record<string, string>
+}
+
 function generateBin(
   bin: ExportsOptions['bin'],
   pkg: PackageJson,
@@ -452,8 +468,11 @@ function generateBin(
   pkgRoot: string,
   logger: Logger,
   cwd: string,
-): string | Record<string, string> | undefined {
-  if (!bin) return
+  devExports: ExportsOptions['devExports'],
+): GeneratedBin {
+  if (!bin) return {}
+
+  const useSourceBin = devExports === true
 
   if (bin === true || typeof bin === 'string') {
     if (!pkg.name)
@@ -464,7 +483,7 @@ function generateBin(
     const binName = pkg.name[0] === '@' ? pkg.name.split('/', 2)[1] : pkg.name
 
     if (bin === true) {
-      let detected: string | undefined
+      let detected: { dist: string; source: string } | undefined
       const seen = new Set<string>()
 
       for (const format of ['es', 'cjs'] as const) {
@@ -482,7 +501,10 @@ function generateBin(
               'Multiple entry chunks with shebangs found. Use `exports.bin: { name: "./src/file.ts" }` to specify which one to use.',
             )
           }
-          detected = join(pkgRoot, chunk.outDir, slash(chunk.fileName))
+          detected = {
+            dist: join(pkgRoot, chunk.outDir, slash(chunk.fileName)),
+            source: relativePackagePath(pkgRoot, chunk.facadeModuleId),
+          }
         }
       }
 
@@ -490,9 +512,9 @@ function generateBin(
         logger.warn(
           '`exports.bin` is true but no entry chunks with shebangs were found',
         )
-        return
+        return {}
       }
-      return { [binName]: detected }
+      return genBin(binName, detected)
     }
 
     if (typeof bin === 'string') {
@@ -500,12 +522,13 @@ function generateBin(
       if (!match) {
         throw new Error(`Could not find output chunk for bin entry "${bin}"`)
       }
-      return { [binName]: match }
+      return genBin(binName, match)
     }
   }
 
   // Object form: { commandName: './src/file.ts' }
   const result: Record<string, string> = {}
+  const publishResult: Record<string, string> = {}
   for (const [cmdName, sourcePath] of Object.entries(bin)) {
     const match = findChunkBySource(sourcePath)
     if (!match) {
@@ -513,11 +536,26 @@ function generateBin(
         `Could not find output chunk for bin entry "${cmdName}": "${sourcePath}"`,
       )
     }
-    result[cmdName] = match
+    result[cmdName] = useSourceBin ? match.source : match.dist
+    if (useSourceBin) publishResult[cmdName] = match.dist
   }
-  return result
+  return useSourceBin
+    ? { bin: result, publishBin: publishResult }
+    : { bin: result }
 
-  function findChunkBySource(sourcePath: string): string | undefined {
+  function genBin(
+    binName: string,
+    match: { dist: string; source: string },
+  ): GeneratedBin {
+    const generatedBin = { [binName]: useSourceBin ? match.source : match.dist }
+    return useSourceBin
+      ? { bin: generatedBin, publishBin: { [binName]: match.dist } }
+      : { bin: generatedBin }
+  }
+
+  function findChunkBySource(
+    sourcePath: string,
+  ): { dist: string; source: string } | undefined {
     const resolved = path.resolve(cwd, sourcePath)
 
     for (const format of ['es', 'cjs'] as const) {
@@ -532,7 +570,10 @@ function generateBin(
             `Bin entry "${sourcePath}" does not contain a shebang line`,
           )
         }
-        return join(pkgRoot, chunk.outDir, slash(chunk.fileName))
+        return {
+          dist: join(pkgRoot, chunk.outDir, slash(chunk.fileName)),
+          source: relativePackagePath(pkgRoot, resolved),
+        }
       }
     }
   }
@@ -555,4 +596,8 @@ function getExportName(
 function join(pkgRoot: string, outDir: string, fileName: string) {
   const outDirRelative = slash(path.relative(pkgRoot, outDir))
   return `${outDirRelative ? `./${outDirRelative}` : '.'}/${fileName}`
+}
+
+function relativePackagePath(pkgRoot: string, filePath: string) {
+  return `./${slash(path.relative(pkgRoot, filePath))}`
 }

--- a/src/features/pkg/exports.ts
+++ b/src/features/pkg/exports.ts
@@ -361,9 +361,7 @@ export async function generateExports(
     types: legacy ? cjsTypes || esmTypes || pkg.types : pkg.types,
     exports,
     bin: generatedBin.bin,
-    ...(generatedBin.publishBin === undefined
-      ? {}
-      : { publishBin: generatedBin.publishBin }),
+    publishBin: generatedBin.publishBin,
     inlinedDependencies: emitInlinedDeps ? inlinedDeps : undefined,
     publishExports,
   }


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

When `exports.devExports: true` is used with `exports.bin`, top-level `bin` now points to source files, while `publishConfig.bin` points to built output.

### Linked Issues

Fixes #908 
