### PR TITLE
fix(css): detect css modules from full id for vue virtual sfc styles

### DIFF
--- a/packages/css/src/plugin.ts
+++ b/packages/css/src/plugin.ts
@@ -115,9 +115,7 @@ export function CssPlugin(
 
         const isInline = RE_INLINE.test(id)
         const isModule =
-          !isInline &&
-          cssConfig.css.modules !== false &&
-          CSS_MODULE_RE.test(cleanId)
+          !isInline && cssConfig.css.modules !== false && CSS_MODULE_RE.test(id)
 
         const deps: string[] = []
         let modules: Record<string, string> | undefined

--- a/tests/__snapshots__/issues/916.snap.md
+++ b/tests/__snapshots__/issues/916.snap.md
@@ -1,0 +1,33 @@
+## index.mjs
+
+```mjs
+import { createElementBlock, normalizeClass, openBlock } from "vue";
+//#region MyButton.vue?vue&type=style&index=0&lang.module.css
+var MyButton_vue_vue_type_style_index_0_lang_module_default = { "btn": "mod_btn" };
+//#endregion
+//#region \0/plugin-vue/export-helper
+var export_helper_default = (sfc, props) => {
+	const target = sfc.__vccOpts || sfc;
+	for (const [key, val] of props) target[key] = val;
+	return target;
+};
+//#endregion
+//#region MyButton.vue
+const _sfc_main = {};
+function _sfc_render(_ctx, _cache) {
+	return openBlock(), createElementBlock("button", { class: normalizeClass(_ctx.$style.btn) }, "Click", 2);
+}
+var MyButton_default = /* @__PURE__ */ export_helper_default(_sfc_main, [["render", _sfc_render], ["__cssModules", { "$style": MyButton_vue_vue_type_style_index_0_lang_module_default }]]);
+//#endregion
+export { MyButton_default as MyButton };
+
+```
+
+## style.css
+
+```css
+.mod_btn {
+  color: red;
+}
+
+```

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -252,6 +252,29 @@ button {
     expect(css).toMatch(/\[data-v-[\da-f]+\]/)
   })
 
+  test('#916', async (context) => {
+    const Vue = (await import('unplugin-vue/rolldown')).default
+    const { outputFiles, fileMap } = await testBuild({
+      context,
+      files: {
+        'index.ts': `export { default as MyButton } from './MyButton.vue'`,
+        'MyButton.vue': `<template><button :class="$style.btn">Click</button></template>
+<style module>
+.btn { color: red; }
+</style>`,
+      },
+      options: {
+        plugins: [Vue({ isProduction: true })],
+        deps: { skipNodeModulesBundle: true },
+        css: { modules: { generateScopedName: 'mod_[local]' } },
+      },
+    })
+    expect(outputFiles).toContain('index.mjs')
+    expect(outputFiles).toContain('style.css')
+    expect(fileMap['style.css']).toContain('.mod_btn')
+    expect(fileMap['index.mjs']).toContain('mod_btn')
+  })
+
   test('#903', async (context) => {
     const { outputFiles } = await testBuild({
       context,


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

tsdown's `@tsdown/css` plugin was matching `CSS_MODULE_RE` against the cleaned path (everything before `?`), so Vue SFC virtual modules like `Component.vue?vue&type=style&index=0&lang.module.css` were never treated as CSS modules — the module map stayed empty and rolldown errored with `"default" is not exported`. Matching against the full `id` (including query) aligns with Vite (`packages/vite/src/node/plugins/css.ts:1513`) and fixes the build.

### Linked Issues

fixes #916

### Additional context

Added a regression test under `tests/issues.test.ts` using `unplugin-vue/rolldown` with a `<style module>` block; the snapshot at `tests/__snapshots__/issues/916.snap.md` confirms `{ "btn": "mod_btn" }` is exported and `.mod_btn` appears in the emitted CSS.