### PR TITLE
feat(config): track transitive config dependencies for watch reload

### DIFF
--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -233,6 +233,7 @@ export type ResolvedConfig = Overwrite<MarkPartial<Omit<UserConfig, "workspace" 
   ignoreWatch: Array<string | RegExp>;
   deps: ResolvedDepsConfig;
   root: string;
+  configDeps: Set<string>;
   dts: false | DtsOptions;
   report: false | ReportOptions;
   tsconfig: false | string;
@@ -262,11 +263,11 @@ export type WithEnabled<T> = boolean | undefined | CIOption | (T & {
 
 // Functions
 export declare function build(_?: InlineConfig): Promise<TsdownBundle[]>;
-export declare function buildWithConfigs(_: ResolvedConfig[], _: string[], _: () => void): Promise<TsdownBundle[]>;
+export declare function buildWithConfigs(_: ResolvedConfig[], _: Set<string>, _: () => void): Promise<TsdownBundle[]>;
 export declare function defineConfig(_: UserConfigExport): UserConfigExport;
 export declare function enableDebug(_?: boolean | Arrayable<string>): void;
 export declare function mergeConfig(_: InlineConfig, ..._: InlineConfig[]): InlineConfig;
-export declare function resolveUserConfig(_: UserConfig, _: InlineConfig): Promise<ResolvedConfig[]>;
+export declare function resolveUserConfig(_: UserConfig, _: InlineConfig, _: Set<string>): Promise<ResolvedConfig[]>;
 
 // Variables
 export declare const globalLogger: Logger;

--- a/__snapshots__/tsnapi/index.snapshot.js
+++ b/__snapshots__/tsnapi/index.snapshot.js
@@ -6,5 +6,5 @@ export { defineConfig }
 export function enableDebug(_) {}
 export var globalLogger /* const */
 export function mergeConfig(_, ..._) {}
-export async function resolveUserConfig(_, _) {}
+export async function resolveUserConfig(_, _, _) {}
 export { Rolldown }

--- a/__snapshots__/tsnapi/plugins.snapshot.d.ts
+++ b/__snapshots__/tsnapi/plugins.snapshot.d.ts
@@ -14,7 +14,7 @@ export declare function DepsPlugin({
 export declare function NodeProtocolPlugin(_: "strip" | true): Plugin;
 export declare function ReportPlugin(_: ResolvedConfig, _?: boolean, _?: boolean): Plugin;
 export declare function ShebangPlugin(_: Logger, _: string, _?: string, _?: boolean): Plugin;
-export declare function WatchPlugin(_: string[], {
+export declare function WatchPlugin(_: Set<string>, {
   config,
   chunks
 }: TsdownBundle): Plugin;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ catalogs:
       specifier: ^7.7.1
       version: 7.7.1
     '@typescript/native-preview':
-      specifier: 7.0.0-dev.20260415.1
-      version: 7.0.0-dev.20260415.1
+      specifier: 7.0.0-dev.20260416.1
+      version: 7.0.0-dev.20260416.1
     '@vitest/coverage-v8':
       specifier: ^4.1.4
       version: 4.1.4
@@ -74,8 +74,8 @@ catalogs:
       specifier: ^1.99.0
       version: 1.99.0
     tsnapi:
-      specifier: ^0.2.0
-      version: 0.2.0
+      specifier: ^0.2.2
+      version: 0.2.2
     typescript:
       specifier: ~6.0.2
       version: 6.0.2
@@ -177,8 +177,8 @@ catalogs:
       specifier: ^6.1.1
       version: 6.1.1
     import-without-cache:
-      specifier: ^0.2.5
-      version: 0.2.5
+      specifier: ^0.3.0
+      version: 0.3.0
     is-in-ci:
       specifier: ^2.0.0
       version: 2.0.0
@@ -245,7 +245,7 @@ importers:
         version: 6.1.1
       import-without-cache:
         specifier: catalog:prod
-        version: 0.2.5
+        version: 0.3.0
       obug:
         specifier: catalog:prod
         version: 2.1.1
@@ -257,7 +257,7 @@ importers:
         version: 1.0.0-rc.15
       rolldown-plugin-dts:
         specifier: catalog:prod
-        version: 0.23.2(@typescript/native-preview@7.0.0-dev.20260415.1)(rolldown@1.0.0-rc.15)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.23.2(@typescript/native-preview@7.0.0-dev.20260416.1)(rolldown@1.0.0-rc.15)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       semver:
         specifier: catalog:prod
         version: 7.7.4
@@ -306,7 +306,7 @@ importers:
         version: 7.7.1
       '@typescript/native-preview':
         specifier: catalog:dev
-        version: 7.0.0-dev.20260415.1
+        version: 7.0.0-dev.20260416.1
       '@unocss/eslint-plugin':
         specifier: catalog:docs
         version: 66.6.8(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
@@ -366,7 +366,7 @@ importers:
         version: 1.99.0
       tsnapi:
         specifier: catalog:dev
-        version: 0.2.0(vitest@4.1.4)
+        version: 0.2.2(vitest@4.1.4)
       typescript:
         specifier: catalog:dev
         version: 6.0.2
@@ -1884,43 +1884,43 @@ packages:
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260415.1':
-    resolution: {integrity: sha512-yGyyDb9bP3XfaIm8VUiaq7xkKwFSxLQ44XGYV78lrne12GhXgZ7Smbf2BVnT5MrTgT5uooMzww85P3I3XNVZng==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-C+apBESKbPP2WiWkQH9z14UErEB7hbSLisxx7CdHEwjt80cN7Xh09qcFPe+b8ouMtsVNVNAQUYpZyCI5+/6Y9A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260415.1':
-    resolution: {integrity: sha512-vzac8BSbSkGPV/FMKyY/3cNZN+FgvjT1E+NNR8xWO8DfvSz4hYqbxvAL+zWPUno6R8afNFLZeJTfuIge0tJJ1g==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-TKHD0tNPcm1vrpEf5yun3VqrNTDTM3KYBj6Ize305CgFuGdtVLGWPJQ4DobUUliR68RzrnDRTt+u1nc70hcEHg==}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260415.1':
-    resolution: {integrity: sha512-jiXu+SrpCL/6J3LwuUSxU8scYs5H0wBkqu3CopdSTcJxQuzUDe6QAEoEW3O81cdrsq5qrIlfFxWH3bdohsvhJA==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-wxsJYr+UXzEevoktqhLa8slPTuMeFn/zROkiT6BcagWkM/H+/dxEFHOhM4HNgAemTJOp4cGyxXSRNHswgiUWsg==}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260415.1':
-    resolution: {integrity: sha512-1CI2nLfsoEibEAt6ApMVEr5M/v9EeXHmn9iD2nyyomO34ky3zqBtEPHakvgXD4QmpZg9O4WxRKc6u6EIy0Imxg==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-EKchoSx8/Gv3HgsTgSSK5FU5ODZQ6hd+qxdgc5c9QTS+2WSN5UX54wCz7wjipHMrTq4mGnqXLfgVSl2JlGY1TA==}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260415.1':
-    resolution: {integrity: sha512-+4r4UqGE5ccy9vJNOhjXTqbZPkVGlqdiEgTJbdz8+EpUNQaLGMBhDj1cBMdrdK1YRuj/3C+pLfE3PD9kEsxf6Q==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-ey6Gvb5OqaOVxx8Ur5LVAbe07VEwyoFkb6v9zlN9Q/lR0DeJB/sFVZ53CIDuded5KG+zbLcGVJXLn3HDJQmzXA==}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260415.1':
-    resolution: {integrity: sha512-QsCAG7la4GE4Dp7i9MUz7Qv+HbKVDdmwlmn+8sOo0M3aSC6WssCU5gKVBUjp43WPtml/JticwzSz1qXLfdxHFA==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-JrxGuXGthBtKt3kc987XQDhorn+XXCXffbd/a9rc1XZ8koOhS/rZAnLv7dHx7m9DLtUXAPPpe+3vu25WfPfuzg==}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260415.1':
-    resolution: {integrity: sha512-Z+rclKC7FqkUsqQ+ErgWJmf5J55LEl/rooFq71prC6V0vCBa5yLMmLBmFxZLLj2BsCBuwbN2O7aWUWrpCUEkmw==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-Ht04G9kt0fopDA0cB1Ng7/X6SScRIXaKZk9m/guyesuRlt3el+9eefF6YrnYCczzKlmZ4doPbR/xXiKFSnZA6Q==}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260415.1':
-    resolution: {integrity: sha512-kRQ0x4DgXZBI0bNTck65EUaj48+hbMlCHiJKfc0Se5ZVUG0SKRC6JBPLwIBCX5TfljKsm8SstuJ3qn6uw1IWpA==}
+  '@typescript/native-preview@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-DcmbOGc6m0YufnSdXb8OIfyl7J1MrjSy2Sz1vqe9xVw3/o+i3d/H46oOlGiEdVmFDhV4+xFTyd/OpJ3XK2+wrQ==}
     hasBin: true
 
   '@typescript/vfs@1.6.4':
@@ -2485,8 +2485,8 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
-  electron-to-chromium@1.5.338:
-    resolution: {integrity: sha512-KVQQ3xko9/coDX3qXLUEEbqkKT8L+1DyAovrtu0Khtrt9wjSZ+7CZV4GVzxFy9Oe1NbrIU1oVXCwHJruIA1PNg==}
+  electron-to-chromium@1.5.339:
+    resolution: {integrity: sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2970,8 +2970,8 @@ packages:
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
-  import-without-cache@0.2.5:
-    resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
+  import-without-cache@0.3.0:
+    resolution: {integrity: sha512-cHk6lns6un55r3vS1H2L7OjM0wGWmwcwgOlCRd7FlW/2HdtvBb/reYsV+yuy5jcnOp63xjAgFxbFJDLkUBu1ow==}
     engines: {node: '>=20.19.0'}
 
   imurmurhash@0.1.4:
@@ -4139,8 +4139,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsnapi@0.2.0:
-    resolution: {integrity: sha512-J4vJn78ehrD1AOc/TE/EcmIT/6kXYdVbLsSYUkqyZj8JwY0xxZ62T6qnY+HP3s7FxgmedeaUIm4X8kn7ZETmCQ==}
+  tsnapi@0.2.2:
+    resolution: {integrity: sha512-DRv8206/u6bnzX/KQfN778bJzB9xga24BjYhPsKpGrM3SEBDrKWBmDrdbDRxqudOfAbFinwJkFT1uFhwIJEH0w==}
     hasBin: true
     peerDependencies:
       vitest: '>=4.0.0'
@@ -5731,8 +5731,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.58.0(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@6.0.2)
-      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/types': 8.58.2
       debug: 4.4.3
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -5857,36 +5857,36 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260415.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260416.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260415.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260416.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260415.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260416.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260415.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260416.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260415.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260416.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260415.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260416.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260415.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260416.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260415.1':
+  '@typescript/native-preview@7.0.0-dev.20260416.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260415.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260415.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260415.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260415.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260415.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260415.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260415.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260416.1
 
   '@typescript/vfs@1.6.4(typescript@6.0.2)':
     dependencies:
@@ -6424,7 +6424,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.19
       caniuse-lite: 1.0.30001788
-      electron-to-chromium: 1.5.338
+      electron-to-chromium: 1.5.339
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -6586,7 +6586,7 @@ snapshots:
 
   duplexer@0.1.2: {}
 
-  electron-to-chromium@1.5.338: {}
+  electron-to-chromium@1.5.339: {}
 
   emoji-regex@8.0.0: {}
 
@@ -7091,7 +7091,7 @@ snapshots:
 
   import-meta-resolve@4.2.0: {}
 
-  import-without-cache@0.2.5: {}
+  import-without-cache@0.3.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -8105,7 +8105,7 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rolldown-plugin-dts@0.23.2(@typescript/native-preview@7.0.0-dev.20260415.1)(rolldown@1.0.0-rc.15)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2)):
+  rolldown-plugin-dts@0.23.2(@typescript/native-preview@7.0.0-dev.20260416.1)(rolldown@1.0.0-rc.15)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -8119,7 +8119,7 @@ snapshots:
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.15
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260415.1
+      '@typescript/native-preview': 7.0.0-dev.20260416.1
       typescript: 6.0.2
       vue-tsc: 3.2.6(typescript@6.0.2)
     transitivePeerDependencies:
@@ -8432,7 +8432,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsnapi@0.2.0(vitest@4.1.4):
+  tsnapi@0.2.2(vitest@4.1.4):
     dependencies:
       '@vitest/utils': 4.1.4
       cac: 7.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ catalogs:
       specifier: ^6.1.1
       version: 6.1.1
     import-without-cache:
-      specifier: ^0.3.0
-      version: 0.3.0
+      specifier: ^0.3.3
+      version: 0.3.3
     is-in-ci:
       specifier: ^2.0.0
       version: 2.0.0
@@ -245,7 +245,7 @@ importers:
         version: 6.1.1
       import-without-cache:
         specifier: catalog:prod
-        version: 0.3.0
+        version: 0.3.3
       obug:
         specifier: catalog:prod
         version: 2.1.1
@@ -2970,8 +2970,8 @@ packages:
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
-  import-without-cache@0.3.0:
-    resolution: {integrity: sha512-cHk6lns6un55r3vS1H2L7OjM0wGWmwcwgOlCRd7FlW/2HdtvBb/reYsV+yuy5jcnOp63xjAgFxbFJDLkUBu1ow==}
+  import-without-cache@0.3.3:
+    resolution: {integrity: sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ==}
     engines: {node: '>=20.19.0'}
 
   imurmurhash@0.1.4:
@@ -7091,7 +7091,7 @@ snapshots:
 
   import-meta-resolve@4.2.0: {}
 
-  import-without-cache@0.3.0: {}
+  import-without-cache@0.3.3: {}
 
   imurmurhash@0.1.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,7 +70,7 @@ catalogs:
     defu: ^6.1.7
     empathic: ^2.0.0
     hookable: ^6.1.1
-    import-without-cache: ^0.3.0
+    import-without-cache: ^0.3.3
     is-in-ci: ^2.0.0
     lightningcss: ^1.32.0
     obug: ^2.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ catalogs:
     '@types/node': ^25.6.0
     '@types/picomatch': ^4.0.3
     '@types/semver': ^7.7.1
-    '@typescript/native-preview': 7.0.0-dev.20260415.1
+    '@typescript/native-preview': 7.0.0-dev.20260416.1
     '@vitest/coverage-v8': ^4.1.4
     '@vitest/ui': ^4.1.4
     baseline-browser-mapping: ^2.10.19
@@ -32,7 +32,7 @@ catalogs:
     prettier: ^3.8.3
     rolldown-plugin-require-cjs: ^0.4.0
     sass: ^1.99.0
-    tsnapi: ^0.2.0
+    tsnapi: ^0.2.2
     typescript: ~6.0.2
     unplugin-ast: ^0.16.0
     unplugin-raw: ^0.7.0
@@ -70,7 +70,7 @@ catalogs:
     defu: ^6.1.7
     empathic: ^2.0.0
     hookable: ^6.1.1
-    import-without-cache: ^0.2.5
+    import-without-cache: ^0.3.0
     is-in-ci: ^2.0.0
     lightningcss: ^1.32.0
     obug: ^2.1.1

--- a/src/build.ts
+++ b/src/build.ts
@@ -44,9 +44,9 @@ export async function build(
   inlineConfig: InlineConfig = {},
 ): Promise<TsdownBundle[]> {
   globalLogger.level = inlineConfig.logLevel || 'info'
-  const { configs, files: configFiles } = await resolveConfig(inlineConfig)
+  const { configs, deps: configDeps } = await resolveConfig(inlineConfig)
 
-  return buildWithConfigs(configs, configFiles, () => build(inlineConfig))
+  return buildWithConfigs(configs, configDeps, () => build(inlineConfig))
 }
 
 /**
@@ -57,7 +57,7 @@ export async function build(
  */
 export async function buildWithConfigs(
   configs: ResolvedConfig[],
-  configFiles: string[],
+  configDeps: Set<string>,
   _restart: () => void,
 ): Promise<TsdownBundle[]> {
   let cleanPromise: Promise<void> | undefined
@@ -91,7 +91,7 @@ export async function buildWithConfigs(
         : true
       return buildSingle(
         options,
-        configFiles,
+        configDeps,
         isDualFormat,
         clean,
         restart,
@@ -126,7 +126,7 @@ export async function buildWithConfigs(
  */
 async function buildSingle(
   config: ResolvedConfig,
-  configFiles: string[],
+  configDeps: Set<string>,
   isDualFormat: boolean,
   clean: () => Promise<void>,
   restart: () => void,
@@ -199,7 +199,7 @@ async function buildSingle(
         debouncedPostBuild.cancel()
         ab?.abort()
       }
-      if (configFiles.includes(id) || endsWithConfig.test(id)) {
+      if (configDeps.has(id) || endsWithConfig.test(id)) {
         globalLogger.info(`Reload config: ${id}, restarting...`)
         restart()
       }
@@ -270,7 +270,7 @@ async function buildSingle(
     const buildOptions = await getBuildOptions(
       config,
       format,
-      configFiles,
+      configDeps,
       bundle,
       false,
       isDualFormat,
@@ -294,7 +294,7 @@ async function buildSingle(
         await getBuildOptions(
           config,
           format,
-          configFiles,
+          configDeps,
           bundle,
           true, // cjsDts
           isDualFormat,

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import { underline } from 'ansis'
-import { init, isSupported } from 'import-without-cache'
+import { depsStore, init, isSupported } from 'import-without-cache'
 import isInCi from 'is-in-ci'
 import { createDebug } from 'obug'
 import { createConfigCoreLoader } from 'unconfig-core'
@@ -23,11 +23,13 @@ export async function loadViteConfig(
   prefix: string,
   cwd: string,
   configLoader: InlineConfig['configLoader'],
-): Promise<ViteUserConfig | undefined> {
+): Promise<{ config: ViteUserConfig; deps?: Set<string> } | undefined> {
   const loader = resolveConfigLoader(configLoader)
   debug('Loading Vite config via loader: ', loader)
   const parser = createParser(loader)
-  const [result] = await createConfigCoreLoader<ViteUserConfigExport>({
+  const [result] = await createConfigCoreLoader<
+    [exported: ViteUserConfigExport, deps: Set<string>]
+  >({
     sources: [
       {
         files: [`${prefix}.config`],
@@ -39,17 +41,24 @@ export async function loadViteConfig(
   }).load(true)
   if (!result) return
 
-  const { config, source } = result
+  let {
+    config: [exported, deps],
+    source,
+  } = result
   globalLogger.info(`Using Vite config: ${underline(source)}`)
 
-  const resolved = await config
-  if (typeof resolved === 'function') {
-    return resolved({
+  exported = await exported
+  if (typeof exported === 'function') {
+    exported = await exported({
       command: 'build',
       mode: 'production',
     } satisfies ConfigEnv)
   }
-  return resolved
+
+  return {
+    config: exported,
+    deps,
+  }
 }
 
 const configPrefix = 'tsdown.config'
@@ -60,7 +69,7 @@ export async function loadConfigFile(
   rootConfig?: UserConfig,
 ): Promise<{
   configs: UserConfig[]
-  file?: string
+  deps?: Set<string>
 }> {
   let cwd = inlineConfig.cwd || process.cwd()
   let overrideConfig = false
@@ -103,7 +112,9 @@ export async function loadConfigFile(
         { files: ['package.json'], parser },
       ]
 
-  const [result] = await createConfigCoreLoader<UserConfigExport>({
+  const [result] = await createConfigCoreLoader<
+    [exported: UserConfigExport, deps: Set<string>]
+  >({
     sources,
     cwd,
     stopAt: workspace && path.dirname(workspace),
@@ -111,8 +122,13 @@ export async function loadConfigFile(
 
   let exported: UserConfigExport = []
   let file: string | undefined
+  let deps: Set<string> | undefined
   if (result) {
-    ;({ config: exported, source: file } = result)
+    ;({
+      config: [exported, deps],
+      source: file,
+    } = result)
+
     globalLogger.info(
       `config file: ${underline(file)}`,
       loader === 'native' ? '' : `(${loader})`,
@@ -140,7 +156,7 @@ export async function loadConfigFile(
       ...config,
       cwd: config.cwd ? path.resolve(cwd, config.cwd) : cwd,
     })),
-    file,
+    deps,
   }
 }
 
@@ -169,21 +185,19 @@ function createParser(loader: Parser) {
     if (isJSON) {
       const contents = await readFile(filepath, 'utf8')
       const parsed = JSON.parse(contents)
-      if (isPkgJson) {
-        return parsed?.tsdown
-      }
-      return parsed
+      const config = isPkgJson ? parsed?.tsdown : parsed
+      return [config, new Set([filepath])]
     }
 
-    if (loader === 'native') {
-      return nativeImport(filepath)
-    }
-
-    return unrunImport(filepath)
+    return (loader === 'native' ? nativeImport : unrunImport)(filepath)
   }
 }
 
-async function nativeImport(id: string) {
+async function nativeImport(
+  id: string,
+): Promise<[module: unknown, deps: Set<string>]> {
+  const deps = new Set<string>()
+
   const url = pathToFileURL(id)
   const importAttributes: Record<string, string> = Object.create(null)
   if (isSupported) {
@@ -193,39 +207,45 @@ async function nativeImport(id: string) {
     url.searchParams.set('no-cache', crypto.randomUUID())
   }
 
-  const mod = await import(url.href, {
-    with: importAttributes,
-  }).catch((error) => {
-    const cannotFindModule = error?.message?.includes?.('Cannot find module')
-    if (cannotFindModule) {
-      const configError = new Error(
-        `Failed to load the config file. Try setting the --config-loader CLI flag to \`unrun\`.\n\n${error.message}`,
-        { cause: error },
-      )
-      throw configError
-    }
+  const mod = await depsStore.run(deps, () =>
+    import(url.href, {
+      with: importAttributes,
+    }).catch((error) => {
+      const cannotFindModule = error?.message?.includes?.('Cannot find module')
+      if (cannotFindModule) {
+        const configError = new Error(
+          `Failed to load the config file. Try setting the --config-loader CLI flag to \`unrun\`.\n\n${error.message}`,
+          { cause: error },
+        )
+        throw configError
+      }
 
-    const nodeInternalBug =
-      typeof error?.stack === 'string' &&
-      error.stack.includes('node:internal/modules/esm/translators')
-    if (nodeInternalBug) {
-      const configError = new Error(
-        `Failed to load the config file due to a known Node.js bug. Try setting the --config-loader CLI flag to \`unrun\` or upgrading Node.js to v24.11.1 or later.\n\n${error.message}`,
-        { cause: error },
-      )
-      throw configError
-    }
+      const nodeInternalBug =
+        typeof error?.stack === 'string' &&
+        error.stack.includes('node:internal/modules/esm/translators')
+      if (nodeInternalBug) {
+        const configError = new Error(
+          `Failed to load the config file due to a known Node.js bug. Try setting the --config-loader CLI flag to \`unrun\` or upgrading Node.js to v24.11.1 or later.\n\n${error.message}`,
+          { cause: error },
+        )
+        throw configError
+      }
 
-    throw error
-  })
+      throw error
+    }),
+  )
+
   const config = mod.default || mod
-  return config
+  return [config, deps]
 }
 
-async function unrunImport(id: string) {
+async function unrunImport(
+  id: string,
+): Promise<[module: unknown, deps: Set<string>]> {
   const { unrun } = await import('unrun')
-  const { module } = await unrun({
+  const { module, dependencies } = await unrun({
     path: pathToFileURL(id).href,
   })
-  return module
+
+  return [module, new Set(dependencies)]
 }

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -196,7 +196,7 @@ function createParser(loader: Parser) {
 async function nativeImport(
   id: string,
 ): Promise<[module: unknown, deps: Set<string>]> {
-  const deps = new Set<string>()
+  const deps = new Set<string>([id])
 
   const url = pathToFileURL(id)
   const importAttributes: Record<string, string> = Object.create(null)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -19,7 +19,7 @@ const debug = createDebug('tsdown:config')
 
 export async function resolveConfig(inlineConfig: InlineConfig): Promise<{
   configs: ResolvedConfig[]
-  files: string[]
+  deps: Set<string>
 }> {
   debug('inline config %O', inlineConfig)
 
@@ -27,34 +27,31 @@ export async function resolveConfig(inlineConfig: InlineConfig): Promise<{
     inlineConfig.cwd = path.resolve(inlineConfig.cwd)
   }
 
-  const { configs: rootConfigs, file } = await loadConfigFile(inlineConfig)
-  const files: string[] = []
-  if (file) {
-    files.push(file)
-    debug('loaded root user config file %s', file)
-    debug('root user configs %O', rootConfigs)
-  } else {
-    debug('no root user config file found')
-  }
+  const { configs: rootConfigs, deps: rootDeps } =
+    await loadConfigFile(inlineConfig)
+  const globalDeps = new Set<string>(rootDeps)
 
   const configs: ResolvedConfig[] = (
     await Promise.all(
       rootConfigs.map(async (rootConfig): Promise<ResolvedConfig[]> => {
-        const { configs: workspaceConfigs, files: workspaceFiles } =
-          await resolveWorkspace(rootConfig, inlineConfig)
+        const { configs: workspaceConfigs, deps: workspaceDeps } =
+          await resolveWorkspace(rootConfig, inlineConfig, rootDeps)
         debug('workspace configs %O', workspaceConfigs)
-        if (workspaceFiles) {
-          files.push(...workspaceFiles)
-        }
-        return (
+
+        const configs = (
           await Promise.all(
             workspaceConfigs
               .filter((config) => !config.workspace || config.entry)
-              .map((config) => resolveUserConfig(config, inlineConfig)),
+              .map((config) =>
+                resolveUserConfig(config, inlineConfig, workspaceDeps),
+              ),
           )
         )
           .flat()
           .filter((config) => !!config)
+
+        workspaceDeps.forEach((dep) => globalDeps.add(dep))
+        return configs
       }),
     )
   ).flat()
@@ -64,5 +61,5 @@ export async function resolveConfig(inlineConfig: InlineConfig): Promise<{
     throw new Error('No valid configuration found.')
   }
 
-  return { configs, files }
+  return { configs, deps: globalDeps }
 }

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -44,6 +44,7 @@ const parseEnv = process.getBuiltinModule('node:util').parseEnv
 export async function resolveUserConfig(
   userConfig: UserConfig,
   inlineConfig: InlineConfig,
+  configDeps: Set<string>,
 ): Promise<ResolvedConfig[]> {
   // Dispatch `tsdownConfig` hook on user plugins before any resolution work.
   // Plugins are snapshotted: new plugins added by a hook don't re-dispatch,
@@ -238,6 +239,8 @@ export async function resolveUserConfig(
   }
   debug(`Environment variables: %O`, env)
 
+  configDeps = new Set(configDeps)
+
   if (fromVite) {
     const viteUserConfig = await loadViteConfig(
       fromVite === true ? 'vite' : fromVite,
@@ -245,8 +248,10 @@ export async function resolveUserConfig(
       inlineConfig.configLoader,
     )
     if (viteUserConfig) {
-      const viteAlias = viteUserConfig.resolve?.alias
+      const { config, deps } = viteUserConfig
+      deps?.forEach((dep) => configDeps.add(dep))
 
+      const viteAlias = config.resolve?.alias
       if ((Array.isArray as (arg: any) => arg is readonly any[])(viteAlias)) {
         throw new TypeError(
           'Unsupported resolve.alias in Vite config. Use object instead of array',
@@ -256,8 +261,8 @@ export async function resolveUserConfig(
         alias = { ...alias, ...viteAlias }
       }
 
-      if (viteUserConfig.plugins) {
-        plugins = [viteUserConfig.plugins as any, plugins]
+      if (config.plugins) {
+        plugins = [config.plugins as any, plugins]
       }
     }
   }
@@ -291,6 +296,7 @@ export async function resolveUserConfig(
     attw,
     cjsDefault,
     clean,
+    configDeps,
     copy: publicDir || copy,
     css,
     cwd,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -697,6 +697,7 @@ export type ResolvedConfig = Overwrite<
     deps: ResolvedDepsConfig
     /** Resolved root directory of input files */
     root: string
+    configDeps: Set<string>
 
     dts: false | DtsOptions
     report: false | ReportOptions

--- a/src/config/workspace.ts
+++ b/src/config/workspace.ts
@@ -19,12 +19,19 @@ const DEFAULT_EXCLUDE_WORKSPACE = [
 export async function resolveWorkspace(
   config: UserConfig,
   inlineConfig: InlineConfig,
-): Promise<{ configs: UserConfig[]; files?: string[] }> {
+  rootDeps?: Set<string>,
+): Promise<{ configs: UserConfig[]; deps: Set<string> }> {
   const normalized = mergeConfig(config, inlineConfig)
   const rootCwd = normalized.cwd || process.cwd()
+  const deps = new Set<string>(rootDeps)
 
   let { workspace } = normalized
-  if (!workspace) return { configs: [normalized], files: [] }
+  if (!workspace) {
+    return {
+      configs: [normalized],
+      deps,
+    }
+  }
 
   if (workspace === true) {
     workspace = {}
@@ -63,12 +70,11 @@ export async function resolveWorkspace(
     throw new Error('No workspace packages found, please check your config')
   }
 
-  const files: string[] = []
   const configs = (
     await Promise.all(
       packages.map(async (cwd) => {
         debug('loading workspace config %s', cwd)
-        const { configs, file } = await loadConfigFile(
+        const { configs, deps: workspaceDeps } = await loadConfigFile(
           {
             ...inlineConfig,
             config: workspaceConfig,
@@ -77,16 +83,11 @@ export async function resolveWorkspace(
           cwd,
           normalized,
         )
-        if (file) {
-          debug('loaded workspace config file %s', file)
-          files.push(file)
-        } else {
-          debug('no workspace config file found in %s', cwd)
-        }
+        workspaceDeps?.forEach((dep) => deps.add(dep))
         return configs.map((config) => mergeConfig(normalized, config))
       }),
     )
   ).flat()
 
-  return { configs, files }
+  return { configs, deps }
 }

--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -36,7 +36,7 @@ const debug = createDebug('tsdown:rolldown')
 export async function getBuildOptions(
   config: ResolvedConfig,
   format: NormalizedFormat,
-  configFiles: string[],
+  configDeps: Set<string>,
   bundle: TsdownBundle,
   cjsDts: boolean = false,
   isDualFormat?: boolean,
@@ -44,7 +44,7 @@ export async function getBuildOptions(
   const inputOptions = await resolveInputOptions(
     config,
     format,
-    configFiles,
+    configDeps,
     bundle,
     cjsDts,
     isDualFormat,
@@ -74,7 +74,7 @@ export async function getBuildOptions(
 async function resolveInputOptions(
   config: ResolvedConfig,
   format: NormalizedFormat,
-  configFiles: string[],
+  configDeps: Set<string>,
   bundle: TsdownBundle,
   cjsDts: boolean,
   isDualFormat?: boolean,
@@ -173,7 +173,7 @@ async function resolveInputOptions(
   }
 
   if (watch) {
-    plugins.push(WatchPlugin(configFiles, bundle))
+    plugins.push(WatchPlugin(configDeps, bundle))
   }
 
   if (!cjsDts) {

--- a/src/features/watch.ts
+++ b/src/features/watch.ts
@@ -8,7 +8,7 @@ export const endsWithConfig: RegExp =
   /[\\/](?:tsdown\.config.*|package\.json|tsconfig\.json)$/
 
 export function WatchPlugin(
-  configFiles: string[],
+  configDeps: Set<string>,
   { config, chunks }: TsdownBundle,
 ): Plugin {
   return {
@@ -22,7 +22,7 @@ export function WatchPlugin(
       : undefined,
     async buildStart() {
       config.tsconfig && this.addWatchFile(config.tsconfig)
-      for (const file of configFiles) {
+      for (const file of configDeps) {
         this.addWatchFile(file)
       }
       if (typeof config.watch !== 'boolean') {

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -2,19 +2,20 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { isDeepStrictEqual } from 'node:util'
 
 export function writeJsonFile(filePath: string, content: unknown): void {
-  let originalContent: unknown = undefined
+  let originalText: string | undefined
+  let originalJson: unknown = undefined
   let originalIndent: string | number = 2
   let originalEOL: string = '\n'
   let originalHasTrailingNewline: boolean = false
 
   try {
-    const text = readFileSync(filePath, 'utf8')
-    originalContent = JSON.parse(text)
-    originalIndent = detectIndentation(text)
-    if (text.includes('\r\n')) {
+    originalText = readFileSync(filePath, 'utf8')
+    originalJson = JSON.parse(originalText)
+    originalIndent = detectIndentation(originalText)
+    if (originalText.includes('\r\n')) {
       originalEOL = '\r\n'
     }
-    if (text.endsWith('\n')) {
+    if (originalText.endsWith('\n')) {
       originalHasTrailingNewline = true
     }
   } catch {
@@ -22,9 +23,9 @@ export function writeJsonFile(filePath: string, content: unknown): void {
   }
 
   if (
-    originalContent &&
-    (isDeepStrictEqual(originalContent, content) ||
-      JSON.stringify(originalContent) === JSON.stringify(content))
+    originalJson &&
+    (isDeepStrictEqual(originalJson, content) ||
+      JSON.stringify(originalJson) === JSON.stringify(content))
   ) {
     // The content is the same. We just return without updating the file format
     return
@@ -38,6 +39,7 @@ export function writeJsonFile(filePath: string, content: unknown): void {
     jsonString += originalEOL
   }
 
+  if (originalText === jsonString) return
   writeFileSync(filePath, jsonString, 'utf8')
 }
 

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,5 +1,4 @@
 import { readFileSync, writeFileSync } from 'node:fs'
-import { isDeepStrictEqual } from 'node:util'
 
 export function writeJsonFile(filePath: string, content: unknown): void {
   let originalContent: unknown = undefined
@@ -21,7 +20,10 @@ export function writeJsonFile(filePath: string, content: unknown): void {
     // File doesn't exist or isn't valid JSON, we'll overwrite it with our content
   }
 
-  if (originalContent && isDeepStrictEqual(originalContent, content)) {
+  if (
+    originalContent &&
+    JSON.stringify(originalContent) === JSON.stringify(content)
+  ) {
     // The content is the same. We just return without updating the file format
     return
   }

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs'
+import { isDeepStrictEqual } from 'node:util'
 
 export function writeJsonFile(filePath: string, content: unknown): void {
   let originalContent: unknown = undefined
@@ -22,7 +23,8 @@ export function writeJsonFile(filePath: string, content: unknown): void {
 
   if (
     originalContent &&
-    JSON.stringify(originalContent) === JSON.stringify(content)
+    (isDeepStrictEqual(originalContent, content) ||
+      JSON.stringify(originalContent) === JSON.stringify(content))
   ) {
     // The content is the same. We just return without updating the file format
     return


### PR DESCRIPTION
- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

Replace `configFiles: string[]` with `configDeps: Set<string>` and track transitive imports of `tsdown.config.ts` (and optional Vite config) via `import-without-cache`'s AsyncLocalStorage `depsStore` and `unrun`'s `dependencies` output.

Watch mode now triggers a full restart when any imported helper of the config changes, not just the config file itself. `Set.has()` also replaces `Array.includes()` for the reload check.

`ResolvedConfig.configDeps` is exposed as part of the public resolved config shape for downstream consumers.

### Linked Issues

### Additional context

- Bumps \`import-without-cache\` catalog to \`^0.3.3\` (exposes \`depsStore\` AsyncLocalStorage).
- On Node versions without \`module.registerHooks\` (\`!isSupported\`) using the \`native\` loader, transitive deps cannot be tracked; behavior falls back to the pre-refactor root-config-only reload. The \`auto\` loader already picks \`unrun\` on those Node versions, which still reports deps.
- Within a workspace, multiple sub-configs share the same \`configDeps\` Set reference by design so that Vite-loaded deps propagate to siblings.