### PR TITLE
fix(shims): use banner injection for unbundle mode

### DIFF
--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -22,7 +22,7 @@ import { NodeProtocolPlugin } from './node-protocol.ts'
 import { resolveChunkAddon, resolveChunkFilename } from './output.ts'
 import { ReportPlugin } from './report.ts'
 import { ShebangPlugin } from './shebang.ts'
-import { getShimsInject } from './shims.ts'
+import { getShimsBanner, getShimsInject } from './shims.ts'
 import { WatchPlugin } from './watch.ts'
 import type {
   DtsOptions,
@@ -195,7 +195,10 @@ async function resolveInputOptions(
       return acc
     }, Object.create(null)),
   }
-  const inject = shims && !cjsDts ? getShimsInject(format, platform) : undefined
+  const inject =
+    shims && !cjsDts
+      ? getShimsInject(format, platform, config.unbundle)
+      : undefined
 
   const inputOptions = await mergeUserOptions(
     {
@@ -249,6 +252,10 @@ async function resolveOutputOptions(
   /// keep-sorted
   const { banner, cjsDefault, footer, minify, outDir, sourcemap, unbundle } =
     config
+  const { platform, shims } = config
+  const shimsBanner =
+    shims && !cjsDts ? getShimsBanner(format, platform, unbundle) : undefined
+  const userBanner = resolveChunkAddon(banner, format)
 
   const [entryFileNames, chunkFileNames] = resolveChunkFilename(
     config,
@@ -267,7 +274,16 @@ async function resolveOutputOptions(
       chunkFileNames,
       preserveModules: unbundle,
       preserveModulesRoot: unbundle ? config.root : undefined,
-      postBanner: resolveChunkAddon(banner, format),
+      postBanner: shimsBanner
+        ? (chunk) => {
+            const userPart =
+              typeof userBanner === 'function'
+                ? userBanner(chunk)
+                : (userBanner ?? '')
+            if (!/\.[mc]?js$/.test(chunk.fileName)) return userPart || ''
+            return userPart ? `${shimsBanner}\n${userPart}` : shimsBanner
+          }
+        : userBanner,
       postFooter: resolveChunkAddon(footer, format),
       codeSplitting: config.exe ? false : undefined,
     },

--- a/src/features/shims.ts
+++ b/src/features/shims.ts
@@ -10,11 +10,24 @@ export const shimFile: string = path.resolve(
 export function getShimsInject(
   format: NormalizedFormat,
   platform: ResolvedConfig['platform'],
+  unbundle?: boolean,
 ): Record<string, [string, string]> | undefined {
+  if (unbundle) return
   if (format === 'es' && platform === 'node') {
     return {
       __dirname: [shimFile, '__dirname'],
       __filename: [shimFile, '__filename'],
     }
+  }
+}
+
+export function getShimsBanner(
+  format: NormalizedFormat,
+  platform: ResolvedConfig['platform'],
+  unbundle?: boolean,
+): string | undefined {
+  if (!unbundle) return
+  if (format === 'es' && platform === 'node') {
+    return 'const __dirname = import.meta.dirname;\nconst __filename = import.meta.filename;'
   }
 }

--- a/tests/__snapshots__/shims/esm-on-node-with-unbundle-and-user-banner.snap.md
+++ b/tests/__snapshots__/shims/esm-on-node-with-unbundle-and-user-banner.snap.md
@@ -1,0 +1,19 @@
+## index.mjs
+
+```mjs
+const __dirname = import.meta.dirname;
+const __filename = import.meta.filename;
+/* custom banner */
+//#region index.ts
+var esm_on_node_with_unbundle_and_user_banner_default = [
+	__dirname,
+	__filename,
+	import.meta.url,
+	import.meta.filename,
+	import.meta.dirname,
+	import.meta.something
+];
+//#endregion
+export { esm_on_node_with_unbundle_and_user_banner_default as default };
+
+```

--- a/tests/__snapshots__/shims/esm-on-node-with-unbundle.snap.md
+++ b/tests/__snapshots__/shims/esm-on-node-with-unbundle.snap.md
@@ -1,0 +1,18 @@
+## index.mjs
+
+```mjs
+const __dirname = import.meta.dirname;
+const __filename = import.meta.filename;
+//#region index.ts
+var esm_on_node_with_unbundle_default = [
+	__dirname,
+	__filename,
+	import.meta.url,
+	import.meta.filename,
+	import.meta.dirname,
+	import.meta.something
+];
+//#endregion
+export { esm_on_node_with_unbundle_default as default };
+
+```

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -39,6 +39,37 @@ describe('shims', () => {
     ])
   })
 
+  test('esm on node with unbundle', async (context) => {
+    const { snapshot } = await testBuild({
+      context,
+      files: { 'index.ts': code },
+      options: {
+        platform: 'node',
+        shims: true,
+        unbundle: true,
+      },
+    })
+    expect(snapshot).contain('import.meta.dirname')
+    expect(snapshot).contain('import.meta.filename')
+    expect(snapshot).not.contain('esm-shims')
+  })
+
+  test('esm on node with unbundle and user banner', async (context) => {
+    const { snapshot } = await testBuild({
+      context,
+      files: { 'index.ts': code },
+      options: {
+        platform: 'node',
+        shims: true,
+        unbundle: true,
+        banner: '/* custom banner */',
+      },
+    })
+    expect(snapshot).contain('import.meta.dirname')
+    expect(snapshot).contain('/* custom banner */')
+    expect(snapshot).not.contain('esm-shims')
+  })
+
   test('cjs on neutral w/o shims', async (context) => {
     const { snapshot } = await testBuild({
       context,


### PR DESCRIPTION
## PR Body

- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

With `shims: true` and `unbundle: true`, `__dirname` and `__filename` resolve to tsdown's own `node_modules` path instead of the consuming file's directory. This happens because Rolldown's `inject` imports from `esm-shims.js`, which stays as an external dependency in unbundle mode — `import.meta.url` inside the shim file points to the shim itself, not the output file.

This PR adds a `getShimsBanner` function that inlines `const __dirname = import.meta.dirname` as a banner when unbundle is enabled, so the values resolve from the correct file. The banner is guarded to JS chunks only so it does not pollute CSS or DTS output. Bundle mode continues to use the existing `inject` path unchanged.

### Linked Issues

Fixes #572

### Additional context

`import.meta.dirname` is available since Node.js 20.11.0, well within the current minimum (20.19.0). User-supplied banners are preserved and appended after the shims banner. All existing shims tests pass unchanged; two new tests verify the unbundle + shims combination and banner coexistence.
