### PR TITLE
fix(pkg): fix duplicate configuration warning logic

### DIFF
--- a/src/features/pkg/index.ts
+++ b/src/features/pkg/index.ts
@@ -95,8 +95,9 @@ export async function bundleDone(
   const publintConfigs = dedupeConfigs(configs, 'publint')
   const attwConfigs = dedupeConfigs(configs, 'attw')
 
-  if (publintConfigs.length > 1 || attwConfigs.length > 1) {
-    publintConfigs[1].logger.warn(
+  const dup = publintConfigs[1] ?? attwConfigs[1]
+  if (dup) {
+    dup.logger.warn(
       `Multiple publint or attw configurations found for package at ${pkg.packageJsonPath}. Consider merging them for better consistency and performance.`,
     )
   }

--- a/src/features/pkg/index.ts
+++ b/src/features/pkg/index.ts
@@ -95,9 +95,9 @@ export async function bundleDone(
   const publintConfigs = dedupeConfigs(configs, 'publint')
   const attwConfigs = dedupeConfigs(configs, 'attw')
 
-  const dup = publintConfigs[1] ?? attwConfigs[1]
-  if (dup) {
-    dup.logger.warn(
+  const duplicate = publintConfigs[1] || attwConfigs[1]
+  if (duplicate) {
+    duplicate.logger.warn(
       `Multiple publint or attw configurations found for package at ${pkg.packageJsonPath}. Consider merging them for better consistency and performance.`,
     )
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.

-->

- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description
`bundleDone()` crashes with `TypeError: Cannot read properties of undefined (reading 'logger')` when only one of `publishConfigs` / `attwConfigs` has length > 1. Falls back to whichever side actually has the duplicate so the warning can be emitted safely.

`dedupeConfigs(configs, 'publint')` collapses to length 1 because `publint: true` is filtered out and falls through to `[filtered[0]]`.
However, `dedupeConfigs(configs, 'attw')` keeps length 2 because each entry's `attw` is a fresh literal and dedupe is reference-based. The `OR`-guarded warning then derefereces `publintConfig[1]` and throws

#### Repro
```ts
import { defineConfig } from 'tsdown';

export default defineConfig([
  { entry: "./a.ts", publint: true, attw: { profile: 'esm-only' } },
  { entry: "./b.ts", publint: true, attw: { profile: 'esm-only' } },
]);
```

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
