### PR TITLE
fix: respect failOnWarn regardless of logger level

### DIFF
--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -9,6 +9,7 @@ import {
   type ExternalOption,
   type ExternalOptionFunction,
   type InputOptions,
+  type LogLevelOption,
   type OutputOptions,
   type Plugin,
   type RolldownPluginOption,
@@ -110,6 +111,7 @@ async function resolveInputOptions(
     unused,
     watch,
   } = config
+  const loggerLevelIndex = LogLevels[logger.level]
 
   const plugins: RolldownPluginOption = []
 
@@ -173,7 +175,7 @@ async function resolveInputOptions(
     }
   }
 
-  if (report && LogLevels[logger.level] >= 3 /* info */) {
+  if (report && loggerLevelIndex >= 3 /* info */) {
     plugins.push(ReportPlugin(config, cjsDts, isDualFormat))
   }
 
@@ -230,6 +232,15 @@ async function resolveInputOptions(
     external = deps.neverBundle
   }
 
+  const logLevel: LogLevelOption =
+    // When failOnWarn is enabled, ensure rolldown's log level is at least
+    // 'warn' so its defaultHandler can escalate warnings to build errors.
+    logger.options?.failOnWarn && loggerLevelIndex < 2 /* warn */
+      ? 'warn'
+      : logger.level === 'error'
+        ? 'silent'
+        : logger.level
+
   const inputOptions = await mergeUserOptions(
     {
       input: entry,
@@ -251,17 +262,7 @@ async function resolveInputOptions(
         '.node': 'copy',
         ...loader,
       },
-      // When failOnWarn is enabled, ensure rolldown's log level is at least
-      // 'warn' so its defaultHandler can escalate warnings to build errors.
-      // Otherwise a caller passing logLevel: 'silent' would never fail because
-      // rolldown's defaultHandler becomes a no-op.
-      logLevel: logger.options?.failOnWarn
-        ? logger.level === 'silent' || logger.level === 'error'
-          ? 'warn'
-          : logger.level
-        : logger.level === 'error'
-          ? 'silent'
-          : logger.level,
+      logLevel,
       onLog(level, log, defaultHandler) {
         // suppress mixed export warnings if cjsDefault is enabled
         if (cjsDefault && log.code === 'MIXED_EXPORT') return

--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -251,7 +251,17 @@ async function resolveInputOptions(
         '.node': 'copy',
         ...loader,
       },
-      logLevel: logger.level === 'error' ? 'silent' : logger.level,
+      // When failOnWarn is enabled, ensure rolldown's log level is at least
+      // 'warn' so its defaultHandler can escalate warnings to build errors.
+      // Otherwise a caller passing logLevel: 'silent' would never fail because
+      // rolldown's defaultHandler becomes a no-op.
+      logLevel: logger.options?.failOnWarn
+        ? logger.level === 'silent' || logger.level === 'error'
+          ? 'warn'
+          : logger.level
+        : logger.level === 'error'
+          ? 'silent'
+          : logger.level,
       onLog(level, log, defaultHandler) {
         // suppress mixed export warnings if cjsDefault is enabled
         if (cjsDefault && log.code === 'MIXED_EXPORT') return

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { RE_NODE_MODULES } from 'rolldown-plugin-dts/internal'
-import { describe, expect, test, vi, type TestContext } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { resolveConfig, type UserConfig } from '../src/config/index.ts'
 import { slash } from '../src/utils/general.ts'
 import { chdir, testBuild, writeFixtures } from './utils.ts'
@@ -1066,88 +1066,6 @@ test('failOnWarn', async (context) => {
       },
     }),
   ).rejects.toThrow('Module not found')
-})
-
-describe('failOnWarn observes warnings independently of logLevel', () => {
-  // testBuild forces rolldown's logLevel to 'info' via its inputOptions
-  // override, so it cannot exercise the silent-mode path. These tests call
-  // build() directly with logLevel: 'silent' to reproduce the bug from #952:
-  // failOnWarn was previously coupled to rolldown's defaultHandler, which
-  // becomes a no-op when logLevel is silent and silently externalised
-  // unresolved imports instead of failing the build.
-
-  async function runIsolatedBuild(
-    context: TestContext,
-    options: {
-      logLevel: 'silent' | 'warn'
-      failOnWarn: boolean
-      entryCode: string
-    },
-  ): Promise<{ rejected: boolean; message?: string }> {
-    const { build } = await import('../src/index.ts')
-    const { testDir } = await writeFixtures(context, {
-      'index.ts': options.entryCode,
-      'package.json': JSON.stringify({ type: 'module', private: true }),
-    })
-    const restoreCwd = chdir(testDir)
-    try {
-      await build({
-        entry: 'index.ts',
-        outDir: 'dist',
-        format: 'esm',
-        platform: 'node',
-        dts: false,
-        config: false,
-        tsconfig: false,
-        logLevel: options.logLevel,
-        failOnWarn: options.failOnWarn,
-        deps: { alwaysBundle: () => true, onlyBundle: false },
-      })
-      return { rejected: false }
-    } catch (error) {
-      return { rejected: true, message: (error as Error).message }
-    } finally {
-      restoreCwd()
-    }
-  }
-
-  test('silent + failOnWarn + warning => build throws', async (context) => {
-    const result = await runIsolatedBuild(context, {
-      logLevel: 'silent',
-      failOnWarn: true,
-      entryCode: `import unresolved from 'unresolved'\nexport const handler = () => unresolved\n`,
-    })
-    expect(result.rejected).toBe(true)
-    expect(result.message).toMatch(/failed|Module not found|unresolved/)
-  })
-
-  test('silent + failOnWarn + clean build => build succeeds', async (context) => {
-    const result = await runIsolatedBuild(context, {
-      logLevel: 'silent',
-      failOnWarn: true,
-      entryCode: `export const handler = () => 1\n`,
-    })
-    expect(result.rejected).toBe(false)
-  })
-
-  test('silent + failOnWarn=false + warning => build succeeds (failOnWarn off respected)', async (context) => {
-    const result = await runIsolatedBuild(context, {
-      logLevel: 'silent',
-      failOnWarn: false,
-      entryCode: `import unresolved from 'unresolved'\nexport const handler = () => unresolved\n`,
-    })
-    expect(result.rejected).toBe(false)
-  })
-
-  test('warn + failOnWarn + warning => still throws (regression preserved)', async (context) => {
-    const result = await runIsolatedBuild(context, {
-      logLevel: 'warn',
-      failOnWarn: true,
-      entryCode: `import unresolved from 'unresolved'\nexport const handler = () => unresolved\n`,
-    })
-    expect(result.rejected).toBe(true)
-    expect(result.message).toMatch(/failed|Module not found|unresolved/)
-  })
 })
 
 describe('resolve dep subpath without exports field', () => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { RE_NODE_MODULES } from 'rolldown-plugin-dts/internal'
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi, type TestContext } from 'vitest'
 import { resolveConfig, type UserConfig } from '../src/config/index.ts'
 import { slash } from '../src/utils/general.ts'
 import { chdir, testBuild, writeFixtures } from './utils.ts'
@@ -1066,6 +1066,88 @@ test('failOnWarn', async (context) => {
       },
     }),
   ).rejects.toThrow('Module not found')
+})
+
+describe('failOnWarn observes warnings independently of logLevel', () => {
+  // testBuild forces rolldown's logLevel to 'info' via its inputOptions
+  // override, so it cannot exercise the silent-mode path. These tests call
+  // build() directly with logLevel: 'silent' to reproduce the bug from #952:
+  // failOnWarn was previously coupled to rolldown's defaultHandler, which
+  // becomes a no-op when logLevel is silent and silently externalised
+  // unresolved imports instead of failing the build.
+
+  async function runIsolatedBuild(
+    context: TestContext,
+    options: {
+      logLevel: 'silent' | 'warn'
+      failOnWarn: boolean
+      entryCode: string
+    },
+  ): Promise<{ rejected: boolean; message?: string }> {
+    const { build } = await import('../src/index.ts')
+    const { testDir } = await writeFixtures(context, {
+      'index.ts': options.entryCode,
+      'package.json': JSON.stringify({ type: 'module', private: true }),
+    })
+    const restoreCwd = chdir(testDir)
+    try {
+      await build({
+        entry: 'index.ts',
+        outDir: 'dist',
+        format: 'esm',
+        platform: 'node',
+        dts: false,
+        config: false,
+        tsconfig: false,
+        logLevel: options.logLevel,
+        failOnWarn: options.failOnWarn,
+        deps: { alwaysBundle: () => true, onlyBundle: false },
+      })
+      return { rejected: false }
+    } catch (error) {
+      return { rejected: true, message: (error as Error).message }
+    } finally {
+      restoreCwd()
+    }
+  }
+
+  test('silent + failOnWarn + warning => build throws', async (context) => {
+    const result = await runIsolatedBuild(context, {
+      logLevel: 'silent',
+      failOnWarn: true,
+      entryCode: `import unresolved from 'unresolved'\nexport const handler = () => unresolved\n`,
+    })
+    expect(result.rejected).toBe(true)
+    expect(result.message).toMatch(/failed|Module not found|unresolved/)
+  })
+
+  test('silent + failOnWarn + clean build => build succeeds', async (context) => {
+    const result = await runIsolatedBuild(context, {
+      logLevel: 'silent',
+      failOnWarn: true,
+      entryCode: `export const handler = () => 1\n`,
+    })
+    expect(result.rejected).toBe(false)
+  })
+
+  test('silent + failOnWarn=false + warning => build succeeds (failOnWarn off respected)', async (context) => {
+    const result = await runIsolatedBuild(context, {
+      logLevel: 'silent',
+      failOnWarn: false,
+      entryCode: `import unresolved from 'unresolved'\nexport const handler = () => unresolved\n`,
+    })
+    expect(result.rejected).toBe(false)
+  })
+
+  test('warn + failOnWarn + warning => still throws (regression preserved)', async (context) => {
+    const result = await runIsolatedBuild(context, {
+      logLevel: 'warn',
+      failOnWarn: true,
+      entryCode: `import unresolved from 'unresolved'\nexport const handler = () => unresolved\n`,
+    })
+    expect(result.rejected).toBe(true)
+    expect(result.message).toMatch(/failed|Module not found|unresolved/)
+  })
 })
 
 describe('resolve dep subpath without exports field', () => {


### PR DESCRIPTION
## Problem

`failOnWarn: true` is documented as a way to fail a build whenever a warning is emitted. In practice it relied on rolldown's `defaultHandler` to escalate `'warn'` into a build error, but when the caller passes `logLevel: 'silent'` rolldown's `defaultHandler` becomes a no-op. So warnings such as unresolved imports get silently externalised and the build succeeds when the user explicitly opted into failing.

A common shape where this bites is CI scripts that pass `logLevel: 'silent'` to keep their own logs clean and `failOnWarn: true` to fail builds with unresolved imports. The current behaviour means those builds silently pass.

## Repro

```ts
import { mkdtempSync, writeFileSync } from 'node:fs'
import { tmpdir } from 'node:os'
import { join } from 'node:path'
import { build } from 'tsdown'

const dir = mkdtempSync(join(tmpdir(), 'tsdown-failonwarn-'))
writeFileSync(
  join(dir, 'package.json'),
  JSON.stringify({ type: 'module', private: true }),
)
writeFileSync(
  join(dir, 'index.ts'),
  `import express from 'express'\nexport const handler = () => express()\n`,
)

await build({
  entry: { index: join(dir, 'index.ts') },
  outDir: join(dir, 'dist'),
  format: 'esm',
  platform: 'node',
  dts: false,
  config: false,
  logLevel: 'silent',
  failOnWarn: true,
  deps: { alwaysBundle: () => true, onlyBundle: false },
})
// before: resolves, unresolved import was silently externalised
// after:  throws "Build failed with 1 error" as expected
```

The same call with `logLevel: 'warn'` already throws, so the bug only surfaces under silent.

## Fix

Decouple rolldown's `logLevel` from tsdown's `logger.level` whenever `failOnWarn` is enabled and the user-facing log level would otherwise suppress warnings:

```ts
logLevel: logger.options?.failOnWarn
  ? logger.level === 'silent' || logger.level === 'error'
    ? 'warn'
    : logger.level
  : logger.level === 'error'
    ? 'silent'
    : logger.level,
```

This keeps existing behaviour for callers who do not set `failOnWarn` and for callers whose `logLevel` already allows warnings. The escalation path inside the `onLog` handler is unchanged.

## Tests

Four direct-build tests added to `tests/e2e.test.ts` that bypass the `testBuild` helper, which is necessary because `testBuild`'s `inputOptions` override forces rolldown's `logLevel` to `'info'` and therefore could never reproduce the silent-mode path. The scenarios cover all four axes:

- **Positive**: silent + `failOnWarn` + warning => `build()` throws.
- **Negative**: silent + `failOnWarn` + clean build (no warnings) => `build()` succeeds.
- **Negative**: silent + `failOnWarn: false` + warning => `build()` succeeds (opt-out respected).
- **Regression preservation**: `warn` + `failOnWarn` + warning => `build()` still throws.

Without the fix the positive scenario fails on `main` (the build resolves silently); the other three pass on baseline already and continue to pass with the patch, confirming the fix narrowly targets the broken path.

`pnpm lint` clean, `pnpm typecheck` clean, full e2e suite green for all 5 `failOnWarn` cases (1 pre-existing + 4 new). The 3 pre-existing `exe.test.ts` failures on `main` are unrelated to this change.

Closes #952

## Note on disclosure

Bug surfacing and the repro are from `@tbeseda` in the issue body. I traced the coupling in `src/features/rolldown.ts`, reproduced it via the script above, applied the minimal log-level decoupling, and added the tests. AI assistance was used while drafting parts of the test boilerplate and this PR body; the fix and tests reflect my own engineering decisions.