### PR TITLE
perf(css): skip renderChunk when no CSS has been collected

### DIFF
--- a/packages/css/src/post.ts
+++ b/packages/css/src/post.ts
@@ -33,6 +33,7 @@ export function CssPostPlugin(
     name: 'tsdown:css-post',
 
     renderChunk(_code, chunk) {
+      if (styles.size === 0) return
       if (config.splitting) return
 
       let chunkCSS = ''


### PR DESCRIPTION
## Problem

I noticed rolldown's `PLUGIN_TIMINGS` warning flagging `tsdown:css-post` at **55–67% of plugin time** on packages that contain **zero CSS files**.

Root cause: `renderChunk` in `CssPostPlugin` is called once per output chunk. In unbundle mode, a large TypeScript-only package (e.g. 818 files) triggers **818 Rust→JS boundary crossings** even when `styles` is always empty. Each call:
1. Allocates via `Object.keys(chunk.modules)`
2. Performs a Map lookup per module ID
3. Returns `null` immediately since no CSS was ever collected

The overhead scales linearly with output file count and is entirely wasted for CSS-free packages.

## Fix

One-line early exit at the top of `renderChunk`:

```ts
if (styles.size === 0) return
```

When no CSS has been collected (no `.css`/`.scss`/`.less` files were transformed), all 818 `renderChunk` calls return immediately without touching `chunk.modules`.

## Result

Before: `PLUGIN_TIMINGS` fires on `@amplitude/types` (818 output files, zero CSS):
```
[PLUGIN_TIMINGS] Your build spent significant time in plugins. Here is a breakdown:
  - tsdown:css-post (64%)
  - rolldown-plugin-dts:fake-js (21%)
```

After: warning gone entirely.