### PR TITLE
ci: generate docs before Void deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,11 @@ on:
       - main
     paths:
       - docs/**
+      - src/**
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
+      - tsconfig.json
       - .github/workflows/src/deploy.yml
       - .github/workflows/deploy.yml
 
@@ -43,6 +45,8 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: pnpm install
+
+      - run: pnpm run docs:generate
 
       - run: pnpm -C docs run void deploy
         env:

--- a/.github/workflows/src/deploy.yml
+++ b/.github/workflows/src/deploy.yml
@@ -7,9 +7,11 @@ on:
     branches: [main]
     paths:
       - docs/**
+      - src/**
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
+      - tsconfig.json
       - .github/workflows/src/deploy.yml
       - .github/workflows/deploy.yml
 
@@ -21,6 +23,7 @@ jobs:
     environment: void
     steps:
       - uses: sxzz/workflows/setup-js@main
+      - run: pnpm run docs:generate
       - run: pnpm -C docs run void deploy
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}


### PR DESCRIPTION
## Summary
- run `pnpm run docs:generate` before `void deploy` so generated API reference pages exist during VitePress build
- include `src/**` and `tsconfig.json` in deploy workflow path filters because TypeDoc reads them

## Fixes
- https://github.com/rolldown/tsdown/actions/runs/27003777935/job/79690217082

## Verification
- pnpm exec actionspack verify
- pnpm run docs:generate && pnpm run docs:build
- git diff --check